### PR TITLE
Fix RK redefinition/duplicate issues

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "ResearchKit"]
-	path = ResearchKit
-	url = git@github.com:Sage-Bionetworks/ResearchKit.git

--- a/BridgeAppSDK.xcodeproj/project.pbxproj
+++ b/BridgeAppSDK.xcodeproj/project.pbxproj
@@ -36,8 +36,11 @@
 		801040F01C5AD29300D26E19 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 801040EC1C5AD29300D26E19 /* LaunchScreen.storyboard */; };
 		801040F11C5AD29300D26E19 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 801040EE1C5AD29300D26E19 /* Main.storyboard */; };
 		801040F31C5AD2D700D26E19 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 801040F21C5AD2D700D26E19 /* Assets.xcassets */; };
-		801040F71C5AD5B200D26E19 /* ResearchKit.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 801DF43C1C5191F50012F509 /* ResearchKit.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		801040F81C5AD5C900D26E19 /* ResearchKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 801DF43C1C5191F50012F509 /* ResearchKit.framework */; };
+		809D4E171C7E88A900EC9EC6 /* ResearchKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 809D4E101C7E886900EC9EC6 /* ResearchKit.framework */; };
+		809D4E181C7E88A900EC9EC6 /* ResearchKit.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 809D4E101C7E886900EC9EC6 /* ResearchKit.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		809D4E1B1C7E88AC00EC9EC6 /* BridgeSDK.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 809D4E021C7E885300EC9EC6 /* BridgeSDK.framework */; };
+		809D4E1C1C7E88AC00EC9EC6 /* BridgeSDK.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 809D4E021C7E885300EC9EC6 /* BridgeSDK.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		809D4E1F1C7E89E300EC9EC6 /* ResearchKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 809D4E101C7E886900EC9EC6 /* ResearchKit.framework */; };
 		80E5A18D1C5ADC7600E0DFE9 /* BridgeAppSDKSample.entitlements in Resources */ = {isa = PBXBuildFile; fileRef = 80E5A18C1C5ADC7600E0DFE9 /* BridgeAppSDKSample.entitlements */; };
 		80E5A1901C5ADF1300E0DFE9 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80E5A18F1C5ADF1300E0DFE9 /* AppDelegate.swift */; };
 		FB14FFDE1C766DF100E0D5AF /* SBAConsentSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB14FFDD1C766DF100E0D5AF /* SBAConsentSection.swift */; };
@@ -56,7 +59,6 @@
 		FBC45E7A1C759040007AA424 /* Localization.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBC45E791C759040007AA424 /* Localization.swift */; };
 		FBE551591C6D204B00C9E1AA /* SBANavigableOrderedTaskTests.m in Sources */ = {isa = PBXBuildFile; fileRef = FBE551581C6D204B00C9E1AA /* SBANavigableOrderedTaskTests.m */; };
 		FBE5515D1C6D267100C9E1AA /* MockORKTask.m in Sources */ = {isa = PBXBuildFile; fileRef = FBE5515C1C6D267100C9E1AA /* MockORKTask.m */; };
-		FBE551671C6D3E7900C9E1AA /* ResearchKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FBE551661C6D3E7900C9E1AA /* ResearchKit.framework */; };
 		FBE551691C6D9CBC00C9E1AA /* SBASurveyNavigationStep.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBE551681C6D9CBC00C9E1AA /* SBASurveyNavigationStep.swift */; };
 /* End PBXBuildFile section */
 
@@ -82,23 +84,79 @@
 			remoteGlobalIDString = 801040B11C5A843D00D26E19;
 			remoteInfo = BridgeAppSDK;
 		};
-		801DF43B1C5191F50012F509 /* PBXContainerItemProxy */ = {
+		809D4E011C7E885300EC9EC6 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
-			containerPortal = 8632A6A91C22215E00557973 /* ResearchKit.xcodeproj */;
+			containerPortal = 809D4DF61C7E885300EC9EC6 /* BridgeSDK.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 80855F5019BE258C006601C7;
+			remoteInfo = BridgeSDK;
+		};
+		809D4E031C7E885300EC9EC6 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 809D4DF61C7E885300EC9EC6 /* BridgeSDK.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 80855F5B19BE258C006601C7;
+			remoteInfo = BridgeSDKTests;
+		};
+		809D4E051C7E885300EC9EC6 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 809D4DF61C7E885300EC9EC6 /* BridgeSDK.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 807AE2871B603309002588BB;
+			remoteInfo = BridgeSDKIntegration;
+		};
+		809D4E071C7E885300EC9EC6 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 809D4DF61C7E885300EC9EC6 /* BridgeSDK.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 807AE29F1B60330C002588BB;
+			remoteInfo = BridgeSDKIntegrationTests;
+		};
+		809D4E0F1C7E886900EC9EC6 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 809D4E091C7E886900EC9EC6 /* ResearchKit.xcodeproj */;
 			proxyType = 2;
 			remoteGlobalIDString = B183A5951A8535D100C76870;
 			remoteInfo = ResearchKit;
 		};
-		801DF43D1C5191F50012F509 /* PBXContainerItemProxy */ = {
+		809D4E111C7E886900EC9EC6 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
-			containerPortal = 8632A6A91C22215E00557973 /* ResearchKit.xcodeproj */;
+			containerPortal = 809D4E091C7E886900EC9EC6 /* ResearchKit.xcodeproj */;
 			proxyType = 2;
 			remoteGlobalIDString = 86CC8E9A1AC09332001CCD89;
 			remoteInfo = ResearchKitTests;
 		};
-		805128841C56E17200D5761D /* PBXContainerItemProxy */ = {
+		809D4E131C7E888900EC9EC6 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
-			containerPortal = 8632A6A91C22215E00557973 /* ResearchKit.xcodeproj */;
+			containerPortal = 809D4E091C7E886900EC9EC6 /* ResearchKit.xcodeproj */;
+			proxyType = 1;
+			remoteGlobalIDString = B183A4731A8535D100C76870;
+			remoteInfo = ResearchKit;
+		};
+		809D4E151C7E888900EC9EC6 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 809D4DF61C7E885300EC9EC6 /* BridgeSDK.xcodeproj */;
+			proxyType = 1;
+			remoteGlobalIDString = 80855F4F19BE258C006601C7;
+			remoteInfo = BridgeSDK;
+		};
+		809D4E191C7E88AA00EC9EC6 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 809D4E091C7E886900EC9EC6 /* ResearchKit.xcodeproj */;
+			proxyType = 1;
+			remoteGlobalIDString = B183A4731A8535D100C76870;
+			remoteInfo = ResearchKit;
+		};
+		809D4E1D1C7E88AE00EC9EC6 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 809D4DF61C7E885300EC9EC6 /* BridgeSDK.xcodeproj */;
+			proxyType = 1;
+			remoteGlobalIDString = 80855F4F19BE258C006601C7;
+			remoteInfo = BridgeSDK;
+		};
+		809D4E201C7E89F200EC9EC6 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 809D4E091C7E886900EC9EC6 /* ResearchKit.xcodeproj */;
 			proxyType = 1;
 			remoteGlobalIDString = B183A4731A8535D100C76870;
 			remoteInfo = ResearchKit;
@@ -112,8 +170,9 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
-				801040F71C5AD5B200D26E19 /* ResearchKit.framework in Embed Frameworks */,
+				809D4E181C7E88A900EC9EC6 /* ResearchKit.framework in Embed Frameworks */,
 				801040C81C5A843D00D26E19 /* BridgeAppSDK.framework in Embed Frameworks */,
+				809D4E1C1C7E88AC00EC9EC6 /* BridgeSDK.framework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -140,10 +199,11 @@
 		801040ED1C5AD29300D26E19 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		801040EF1C5AD29300D26E19 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
 		801040F21C5AD2D700D26E19 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		809D4DF61C7E885300EC9EC6 /* BridgeSDK.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = BridgeSDK.xcodeproj; path = ../../BridgeSDK/BridgeSDK.xcodeproj; sourceTree = "<group>"; };
+		809D4E091C7E886900EC9EC6 /* ResearchKit.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = ResearchKit.xcodeproj; path = ../../ResearchKit/ResearchKit.xcodeproj; sourceTree = "<group>"; };
 		80E5A18C1C5ADC7600E0DFE9 /* BridgeAppSDKSample.entitlements */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = BridgeAppSDKSample.entitlements; sourceTree = "<group>"; };
 		80E5A18E1C5ADF1100E0DFE9 /* BridgeAppSDKSample-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "BridgeAppSDKSample-Bridging-Header.h"; sourceTree = "<group>"; };
 		80E5A18F1C5ADF1300E0DFE9 /* AppDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
-		8632A6A91C22215E00557973 /* ResearchKit.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = ResearchKit.xcodeproj; path = ResearchKit/ResearchKit.xcodeproj; sourceTree = SOURCE_ROOT; };
 		86CCDFF51C1B50970042AA39 /* ResearchContainerViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ResearchContainerViewController.swift; sourceTree = "<group>"; };
 		B5C2073E1BEC16F00051D9D8 /* ResearchContainerSegue.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ResearchContainerSegue.swift; sourceTree = "<group>"; };
 		B5C207411BECBA8B0051D9D8 /* WithdrawViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WithdrawViewController.swift; sourceTree = "<group>"; };
@@ -175,7 +235,6 @@
 		FBE551581C6D204B00C9E1AA /* SBANavigableOrderedTaskTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SBANavigableOrderedTaskTests.m; sourceTree = "<group>"; };
 		FBE5515B1C6D267100C9E1AA /* MockORKTask.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MockORKTask.h; sourceTree = "<group>"; };
 		FBE5515C1C6D267100C9E1AA /* MockORKTask.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MockORKTask.m; sourceTree = "<group>"; };
-		FBE551661C6D3E7900C9E1AA /* ResearchKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = ResearchKit.framework; path = "../researchkit/build/Debug-iphoneos/ResearchKit.framework"; sourceTree = "<group>"; };
 		FBE551681C6D9CBC00C9E1AA /* SBASurveyNavigationStep.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SBASurveyNavigationStep.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -184,7 +243,9 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				809D4E171C7E88A900EC9EC6 /* ResearchKit.framework in Frameworks */,
 				801040C71C5A843D00D26E19 /* BridgeAppSDK.framework in Frameworks */,
+				809D4E1B1C7E88AC00EC9EC6 /* BridgeSDK.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -192,7 +253,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				801040F81C5AD5C900D26E19 /* ResearchKit.framework in Frameworks */,
+				809D4E1F1C7E89E300EC9EC6 /* ResearchKit.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -200,7 +261,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				FBE551671C6D3E7900C9E1AA /* ResearchKit.framework in Frameworks */,
 				801040BC1C5A843D00D26E19 /* BridgeAppSDK.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -211,8 +271,6 @@
 		161479B71BD6CE8F0099A068 = {
 			isa = PBXGroup;
 			children = (
-				FBE551661C6D3E7900C9E1AA /* ResearchKit.framework */,
-				FB68173D1C6D0068006C8FC9 /* BridgeSDK.framework */,
 				801040E51C5AD18100D26E19 /* BridgeAppSDKSample */,
 				161479C21BD6CE8F0099A068 /* BridgeAppSDK */,
 				801040C11C5A843D00D26E19 /* BridgeAppSDKTests */,
@@ -364,16 +422,28 @@
 		801040F51C5AD57E00D26E19 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				8632A6A91C22215E00557973 /* ResearchKit.xcodeproj */,
+				809D4E091C7E886900EC9EC6 /* ResearchKit.xcodeproj */,
+				809D4DF61C7E885300EC9EC6 /* BridgeSDK.xcodeproj */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
 		};
-		801DF4361C5191F40012F509 /* Products */ = {
+		809D4DF71C7E885300EC9EC6 /* Products */ = {
 			isa = PBXGroup;
 			children = (
-				801DF43C1C5191F50012F509 /* ResearchKit.framework */,
-				801DF43E1C5191F50012F509 /* ResearchKitTests.xctest */,
+				809D4E021C7E885300EC9EC6 /* BridgeSDK.framework */,
+				809D4E041C7E885300EC9EC6 /* BridgeSDKTests.xctest */,
+				809D4E061C7E885300EC9EC6 /* BridgeSDKIntegration.app */,
+				809D4E081C7E885300EC9EC6 /* BridgeSDKIntegrationTests.xctest */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		809D4E0A1C7E886900EC9EC6 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				809D4E101C7E886900EC9EC6 /* ResearchKit.framework */,
+				809D4E121C7E886900EC9EC6 /* ResearchKitTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -483,8 +553,11 @@
 			buildRules = (
 			);
 			dependencies = (
-				805128851C56E17200D5761D /* PBXTargetDependency */,
+				809D4E141C7E888900EC9EC6 /* PBXTargetDependency */,
+				809D4E161C7E888900EC9EC6 /* PBXTargetDependency */,
 				801040C61C5A843D00D26E19 /* PBXTargetDependency */,
+				809D4E1A1C7E88AA00EC9EC6 /* PBXTargetDependency */,
+				809D4E1E1C7E88AE00EC9EC6 /* PBXTargetDependency */,
 			);
 			name = BridgeAppSDKSample;
 			productName = ResearchHealth;
@@ -503,6 +576,7 @@
 			buildRules = (
 			);
 			dependencies = (
+				809D4E211C7E89F200EC9EC6 /* PBXTargetDependency */,
 			);
 			name = BridgeAppSDK;
 			productName = BridgeAppSDK;
@@ -567,8 +641,12 @@
 			projectDirPath = "";
 			projectReferences = (
 				{
-					ProductGroup = 801DF4361C5191F40012F509 /* Products */;
-					ProjectRef = 8632A6A91C22215E00557973 /* ResearchKit.xcodeproj */;
+					ProductGroup = 809D4DF71C7E885300EC9EC6 /* Products */;
+					ProjectRef = 809D4DF61C7E885300EC9EC6 /* BridgeSDK.xcodeproj */;
+				},
+				{
+					ProductGroup = 809D4E0A1C7E886900EC9EC6 /* Products */;
+					ProjectRef = 809D4E091C7E886900EC9EC6 /* ResearchKit.xcodeproj */;
 				},
 			);
 			projectRoot = "";
@@ -581,18 +659,46 @@
 /* End PBXProject section */
 
 /* Begin PBXReferenceProxy section */
-		801DF43C1C5191F50012F509 /* ResearchKit.framework */ = {
+		809D4E021C7E885300EC9EC6 /* BridgeSDK.framework */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.framework;
+			path = BridgeSDK.framework;
+			remoteRef = 809D4E011C7E885300EC9EC6 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		809D4E041C7E885300EC9EC6 /* BridgeSDKTests.xctest */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.cfbundle;
+			path = BridgeSDKTests.xctest;
+			remoteRef = 809D4E031C7E885300EC9EC6 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		809D4E061C7E885300EC9EC6 /* BridgeSDKIntegration.app */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.application;
+			path = BridgeSDKIntegration.app;
+			remoteRef = 809D4E051C7E885300EC9EC6 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		809D4E081C7E885300EC9EC6 /* BridgeSDKIntegrationTests.xctest */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.cfbundle;
+			path = BridgeSDKIntegrationTests.xctest;
+			remoteRef = 809D4E071C7E885300EC9EC6 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		809D4E101C7E886900EC9EC6 /* ResearchKit.framework */ = {
 			isa = PBXReferenceProxy;
 			fileType = wrapper.framework;
 			path = ResearchKit.framework;
-			remoteRef = 801DF43B1C5191F50012F509 /* PBXContainerItemProxy */;
+			remoteRef = 809D4E0F1C7E886900EC9EC6 /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
-		801DF43E1C5191F50012F509 /* ResearchKitTests.xctest */ = {
+		809D4E121C7E886900EC9EC6 /* ResearchKitTests.xctest */ = {
 			isa = PBXReferenceProxy;
 			fileType = wrapper.cfbundle;
 			path = ResearchKitTests.xctest;
-			remoteRef = 801DF43D1C5191F50012F509 /* PBXContainerItemProxy */;
+			remoteRef = 809D4E111C7E886900EC9EC6 /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
 /* End PBXReferenceProxy section */
@@ -704,10 +810,30 @@
 			target = 801040B11C5A843D00D26E19 /* BridgeAppSDK */;
 			targetProxy = 801040C51C5A843D00D26E19 /* PBXContainerItemProxy */;
 		};
-		805128851C56E17200D5761D /* PBXTargetDependency */ = {
+		809D4E141C7E888900EC9EC6 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = ResearchKit;
-			targetProxy = 805128841C56E17200D5761D /* PBXContainerItemProxy */;
+			targetProxy = 809D4E131C7E888900EC9EC6 /* PBXContainerItemProxy */;
+		};
+		809D4E161C7E888900EC9EC6 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = BridgeSDK;
+			targetProxy = 809D4E151C7E888900EC9EC6 /* PBXContainerItemProxy */;
+		};
+		809D4E1A1C7E88AA00EC9EC6 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = ResearchKit;
+			targetProxy = 809D4E191C7E88AA00EC9EC6 /* PBXContainerItemProxy */;
+		};
+		809D4E1E1C7E88AE00EC9EC6 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = BridgeSDK;
+			targetProxy = 809D4E1D1C7E88AE00EC9EC6 /* PBXContainerItemProxy */;
+		};
+		809D4E211C7E89F200EC9EC6 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = ResearchKit;
+			targetProxy = 809D4E201C7E89F200EC9EC6 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 


### PR DESCRIPTION
make BridgeAppSDK depend on containing project's ResearchKit module instead of having its own (i.e., the RK module should be in a parallel directory adjacent to BridgeAppSDK's)
