### PR TITLE
Moved stubbed out implementation of the activities view controller into BridgeApp

### DIFF
--- a/BridgeAppSDK.xcodeproj/project.pbxproj
+++ b/BridgeAppSDK.xcodeproj/project.pbxproj
@@ -61,7 +61,7 @@
 		FF2498211CB6E605002DD05F /* SequenceType+Utilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF2498201CB6E605002DD05F /* SequenceType+Utilities.swift */; };
 		FF2498251CB78972002DD05F /* SBATrackedDataObjectTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF2498241CB78972002DD05F /* SBATrackedDataObjectTests.swift */; };
 		FF3A354E1CBDAFE600F44E6E /* UIColor+Utilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF3A354D1CBDAFE600F44E6E /* UIColor+Utilities.swift */; };
-		FF3A359D1CBEB2D400F44E6E /* SBAUIController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF3A359C1CBEB2D400F44E6E /* SBAUIController.swift */; };
+		FF3A359D1CBEB2D400F44E6E /* SBASharedInfoController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF3A359C1CBEB2D400F44E6E /* SBASharedInfoController.swift */; };
 		FF45F8131CA5B57200EE0562 /* SBARootViewControllerProtocol.h in Headers */ = {isa = PBXBuildFile; fileRef = FF45F8121CA5B57200EE0562 /* SBARootViewControllerProtocol.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		FF45F84B1CA5D61900EE0562 /* SBAUserBridgeManager.h in Headers */ = {isa = PBXBuildFile; fileRef = FF45F8491CA5D61900EE0562 /* SBAUserBridgeManager.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		FF45F84C1CA5D61900EE0562 /* SBAUserBridgeManager.m in Sources */ = {isa = PBXBuildFile; fileRef = FF45F84A1CA5D61900EE0562 /* SBAUserBridgeManager.m */; };
@@ -93,6 +93,8 @@
 		FFA8E4AC1CBD756B00ED5399 /* SBAExternalIDOnboardingController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFA8E4AB1CBD756B00ED5399 /* SBAExternalIDOnboardingController.swift */; };
 		FFA8E4AF1CBD7CDA00ED5399 /* SBALoadingViewPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFA8E4AE1CBD7CDA00ED5399 /* SBALoadingViewPresenter.swift */; };
 		FFA8E4B51CBD903000ED5399 /* SBAKeyboardAnimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFA8E4B41CBD903000ED5399 /* SBAKeyboardAnimator.swift */; };
+		FFAAF5FB1CC00CF100500929 /* SBAActivityTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFAAF5FA1CC00CF100500929 /* SBAActivityTableViewController.swift */; };
+		FFAAF5FD1CC00D7300500929 /* SBAActivityTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFAAF5FC1CC00D7300500929 /* SBAActivityTableViewCell.swift */; };
 		FFBB57261CACEAA00041F120 /* SBAActiveTask+Dictionary.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFBB57251CACEAA00041F120 /* SBAActiveTask+Dictionary.swift */; };
 		FFBB57311CACEADF0041F120 /* SBAActiveTaskTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFBB57301CACEADF0041F120 /* SBAActiveTaskTests.swift */; };
 		FFCB98871CAC9000005078EF /* DeprecationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFCB98861CAC9000005078EF /* DeprecationTests.swift */; };
@@ -312,7 +314,7 @@
 		FF2498201CB6E605002DD05F /* SequenceType+Utilities.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "SequenceType+Utilities.swift"; sourceTree = "<group>"; };
 		FF2498241CB78972002DD05F /* SBATrackedDataObjectTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SBATrackedDataObjectTests.swift; sourceTree = "<group>"; };
 		FF3A354D1CBDAFE600F44E6E /* UIColor+Utilities.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIColor+Utilities.swift"; sourceTree = "<group>"; };
-		FF3A359C1CBEB2D400F44E6E /* SBAUIController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SBAUIController.swift; sourceTree = "<group>"; };
+		FF3A359C1CBEB2D400F44E6E /* SBASharedInfoController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SBASharedInfoController.swift; sourceTree = "<group>"; };
 		FF45F8121CA5B57200EE0562 /* SBARootViewControllerProtocol.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SBARootViewControllerProtocol.h; sourceTree = "<group>"; };
 		FF45F8491CA5D61900EE0562 /* SBAUserBridgeManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SBAUserBridgeManager.h; sourceTree = "<group>"; };
 		FF45F84A1CA5D61900EE0562 /* SBAUserBridgeManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SBAUserBridgeManager.m; sourceTree = "<group>"; };
@@ -343,6 +345,8 @@
 		FFA8E4AB1CBD756B00ED5399 /* SBAExternalIDOnboardingController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SBAExternalIDOnboardingController.swift; sourceTree = "<group>"; };
 		FFA8E4AE1CBD7CDA00ED5399 /* SBALoadingViewPresenter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SBALoadingViewPresenter.swift; sourceTree = "<group>"; };
 		FFA8E4B41CBD903000ED5399 /* SBAKeyboardAnimator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SBAKeyboardAnimator.swift; sourceTree = "<group>"; };
+		FFAAF5FA1CC00CF100500929 /* SBAActivityTableViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SBAActivityTableViewController.swift; sourceTree = "<group>"; };
+		FFAAF5FC1CC00D7300500929 /* SBAActivityTableViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SBAActivityTableViewCell.swift; sourceTree = "<group>"; };
 		FFBB57251CACEAA00041F120 /* SBAActiveTask+Dictionary.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "SBAActiveTask+Dictionary.swift"; sourceTree = "<group>"; };
 		FFBB57301CACEADF0041F120 /* SBAActiveTaskTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SBAActiveTaskTests.swift; sourceTree = "<group>"; };
 		FFCB98861CAC9000005078EF /* DeprecationTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DeprecationTests.swift; sourceTree = "<group>"; };
@@ -439,8 +443,8 @@
 		16BF5B611BE29643007C79C6 /* Onboarding */ = {
 			isa = PBXGroup;
 			children = (
-				FBF1B6AD1CAAED0F007C1082 /* UI */,
 				FBF1B6A31CAAED02007C1082 /* Consent */,
+				FBF1B6AD1CAAED0F007C1082 /* UI */,
 			);
 			name = Onboarding;
 			sourceTree = "<group>";
@@ -458,6 +462,8 @@
 		16BF5B671BE29676007C79C6 /* Activities */ = {
 			isa = PBXGroup;
 			children = (
+				FFAAF5FA1CC00CF100500929 /* SBAActivityTableViewController.swift */,
+				FFAAF5FC1CC00D7300500929 /* SBAActivityTableViewCell.swift */,
 			);
 			name = Activities;
 			sourceTree = "<group>";
@@ -634,10 +640,10 @@
 		FBC45E711C758DBA007AA424 /* Library */ = {
 			isa = PBXGroup;
 			children = (
-				FFA8E4AD1CBD7CB700ED5399 /* UI */,
 				FBAD114E1CADA34C005611D0 /* DataModel */,
 				FFC68EED1CA4778D00FF7B07 /* Encryption */,
 				FBC45E721C758DC9007AA424 /* Localization */,
+				FFA8E4AD1CBD7CB700ED5399 /* UI */,
 				FBAE3CE61C86157E003CEC4A /* Utilities */,
 			);
 			name = Library;
@@ -806,7 +812,7 @@
 		FFA8E4AD1CBD7CB700ED5399 /* UI */ = {
 			isa = PBXGroup;
 			children = (
-				FF3A359C1CBEB2D400F44E6E /* SBAUIController.swift */,
+				FF3A359C1CBEB2D400F44E6E /* SBASharedInfoController.swift */,
 				FFA8E4B41CBD903000ED5399 /* SBAKeyboardAnimator.swift */,
 				FFA8E4AE1CBD7CDA00ED5399 /* SBALoadingViewPresenter.swift */,
 			);
@@ -1096,6 +1102,7 @@
 				FBAD11701CADE79E005611D0 /* SBABridgeTask+Dictionary.swift in Sources */,
 				FBF1B6C71CAB0273007C1082 /* SBALocalizationMacroWrapper.m in Sources */,
 				FB6BA0951C7CDA6000C9903F /* SBADirectNavigationStep.swift in Sources */,
+				FFAAF5FB1CC00CF100500929 /* SBAActivityTableViewController.swift in Sources */,
 				FF9634C71C9A0A6600D07595 /* SBASurveyItem+Bridge.swift in Sources */,
 				FBAD115A1CADB2F0005611D0 /* SBADataObject.m in Sources */,
 				FFA8E4AA1CBD6E0B00ED5399 /* NSError+SBBTranslation.swift in Sources */,
@@ -1110,7 +1117,7 @@
 				FBAD116E1CADE55C005611D0 /* SBABridgeTask.swift in Sources */,
 				FF2379AC1CBC41C000F3A943 /* SBATrackedDataObjectCollection.m in Sources */,
 				FF9D4C5B1CA217A7001C293C /* SBABridgeInfo.swift in Sources */,
-				FF3A359D1CBEB2D400F44E6E /* SBAUIController.swift in Sources */,
+				FF3A359D1CBEB2D400F44E6E /* SBASharedInfoController.swift in Sources */,
 				FBE551691C6D9CBC00C9E1AA /* SBASurveyNavigationStep.swift in Sources */,
 				FB0C9EF31CAA52F700BA5B44 /* NSDate+Utilities.swift in Sources */,
 				FF64111C1CB34766007FB9E1 /* SBAMedication.m in Sources */,
@@ -1118,6 +1125,7 @@
 				FFA8E4B51CBD903000ED5399 /* SBAKeyboardAnimator.swift in Sources */,
 				FBC45E6D1C7531E3007AA424 /* SBAConsentDocumentFactory.swift in Sources */,
 				FFA8E4AF1CBD7CDA00ED5399 /* SBALoadingViewPresenter.swift in Sources */,
+				FFAAF5FD1CC00D7300500929 /* SBAActivityTableViewCell.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/BridgeAppSDK/SBAActivityTableViewCell.swift
+++ b/BridgeAppSDK/SBAActivityTableViewCell.swift
@@ -1,5 +1,5 @@
 //
-//  SBAUIController.swift
+//  SBAActivityTableViewCell.swift
 //  BridgeAppSDK
 //
 //  Copyright © 2016 Sage Bionetworks. All rights reserved.
@@ -33,20 +33,29 @@
 
 import UIKit
 
-public protocol SBAUIController {
-}
+public class SBAActivityTableViewCell: UITableViewCell {
+    
+    @IBOutlet weak var uncheckedView: UIView!
+    @IBOutlet weak var checkmarkImageView: UIImageView!
+    @IBOutlet weak var titleLabel: UILabel!
+    @IBOutlet weak var subtitleLabel: UILabel!
+    @IBOutlet weak var timeLabel: UILabel!
+    
+    internal var complete: Bool = false {
+        didSet {
+            self.uncheckedView.hidden = complete
+            self.checkmarkImageView.hidden = !complete
+        }
+    }
+    
+    override public func layoutSubviews() {
+        super.layoutSubviews()
+        
+        self.uncheckedView.layer.borderColor = UIColor.lightGrayColor().CGColor
+        self.uncheckedView.layer.borderWidth = 1
+        self.uncheckedView.layer.cornerRadius = self.uncheckedView.bounds.size.height / 2
+        
+        self.timeLabel.textColor = self.tintColor
+    }
 
-extension SBAUIController {
-    
-    public var sharedAppDelegate: SBASharedAppDelegate {
-        return UIApplication.sharedApplication().delegate as! SBASharedAppDelegate
-    }
-    
-    public var user: SBAUserWrapper {
-        return self.sharedAppDelegate.currentUser
-    }
-    
-    public var bridgeInfo: SBABridgeInfo {
-        return self.sharedAppDelegate.bridgeInfo
-    }
 }

--- a/BridgeAppSDK/SBAActivityTableViewController.swift
+++ b/BridgeAppSDK/SBAActivityTableViewController.swift
@@ -1,0 +1,161 @@
+//
+//  SBAActivityTableViewController.swift
+//  BridgeAppSDK
+//
+//  Copyright © 2016 Sage Bionetworks. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification,
+// are permitted provided that the following conditions are met:
+//
+// 1.  Redistributions of source code must retain the above copyright notice, this
+// list of conditions and the following disclaimer.
+//
+// 2.  Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation and/or
+// other materials provided with the distribution.
+//
+// 3.  Neither the name of the copyright holder(s) nor the names of any contributors
+// may be used to endorse or promote products derived from this software without
+// specific prior written permission. No license is granted to the trademarks of
+// the copyright holders even if such marks are included in this software.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+
+import UIKit
+import ResearchKit
+import BridgeSDK
+
+public class SBAActivityTableViewController: UITableViewController, SBASharedInfoController, ORKTaskViewControllerDelegate {
+    
+    var activities: [SBBScheduledActivity] = []
+    var taskReferenceMap: [String : NSDictionary] = [:]
+    
+    override public func viewWillAppear(animated: Bool) {
+        super.viewWillAppear(animated)
+        self.reloadData()
+    }
+    
+    
+    // MARK: Customizable implementations
+    
+    // TODO: syoung 04/14/2016 This is a WIP first draft of an implementation of schedule fetching that
+    // works for Lilly but is not complete for Parkinsons (which include a separate section for "keep going"
+    // activities *and* includes surveys that are build server-side (currently not supported by this implementation)
+    
+    public func reloadData() {
+        
+        SBAUserBridgeManager.fetchChangesToScheduledActivities(activities, todayOnly: true) { (obj, error) in
+            guard (error == nil), let scheduledActivities = obj as? [SBBScheduledActivity] else { return }
+            
+            // filter the scheduled activities to only include those that *this* version of the app is designed
+            // to be able to handle. Currently, that means only taskReference activities with an identifier that
+            // maps to a known task.
+            self.activities = scheduledActivities.filter({ (activity) -> Bool in
+                guard (activity.activity.task != nil), let taskRef = self.bridgeInfo.taskReferenceWithIdentifier(activity.activity.task.identifier) else {
+                    return false
+                }
+                self.taskReferenceMap[activity.guid] = taskRef
+                return true
+            })
+            
+            // reload table
+            self.tableView.reloadData()
+        }
+    }
+    
+    public func scheduledActivityAtIndexPath(indexPath: NSIndexPath) -> SBBScheduledActivity? {
+        return activities[indexPath.row]
+    }
+    
+    public func dequeueReusableCell(tableView: UITableView, indexPath: NSIndexPath) -> UITableViewCell {
+        return tableView.dequeueReusableCellWithIdentifier("ActivityCell", forIndexPath: indexPath)
+    }
+    
+    public func configureCell(cell: UITableViewCell, tableView: UITableView, indexPath: NSIndexPath) {
+        guard let activityCell = cell as? SBAActivityTableViewCell,
+            let schedule = scheduledActivityAtIndexPath(indexPath) else {
+                return
+        }
+        
+        // The only cell type that is supported in the base implementation is an SBAActivityTableViewCell
+        let activity = schedule.activity
+        activityCell.complete = schedule.isCompleted
+        activityCell.titleLabel.text = activity.label
+        activityCell.subtitleLabel.text = activity.labelDetail
+        activityCell.timeLabel.text = schedule.scheduledTime
+    }
+    
+    
+    // Mark: UITableViewController overrides
+    
+    override public func tableView(tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return activities.count
+    }
+    
+    override public func tableView(tableView: UITableView, cellForRowAtIndexPath indexPath: NSIndexPath) -> UITableViewCell {
+        let cell = dequeueReusableCell(tableView, indexPath: indexPath)
+        configureCell(cell, tableView: tableView, indexPath: indexPath)
+        return cell
+    }
+    
+    override public func tableView(tableView: UITableView, didSelectRowAtIndexPath indexPath: NSIndexPath) {
+        
+        // Only if the task was created should something be done.
+        guard let schedule = scheduledActivityAtIndexPath(indexPath),
+            let task = SBASurveyFactory().createTaskWithTaskReference(schedule.activity.task.identifier) else {
+            return
+        }
+        
+        let taskViewController = ORKTaskViewController(task: task, taskRunUUID: NSUUID(UUIDString: schedule.guid))
+        taskViewController.delegate = self
+        self.presentViewController(taskViewController, animated: true, completion: nil)
+    }
+    
+    
+    // MARK: ORKTaskViewControllerDelegate
+    
+    public func taskViewController(taskViewController: ORKTaskViewController, didFinishWithReason reason: ORKTaskViewControllerFinishReason, error: NSError?) {
+        
+        let guid = taskViewController.taskRunUUID.UUIDString
+        if reason == ORKTaskViewControllerFinishReason.Completed,
+            let schedule = activities.findObject({$0.guid == guid}) {
+            // If completed, the update the finishedOn data 
+            schedule.finishedOn = NSDate()
+            
+            // TODO: syoung 04/12/2016 Archive the result and send to server (spin on a background thread)
+        }
+        
+        taskViewController.dismissViewControllerAnimated(true) {}
+    }
+}
+
+extension SBBScheduledActivity {
+    
+    var isCompleted: Bool {
+        return self.finishedOn != nil
+    }
+    
+    var scheduledTime: String {
+        if (isCompleted) {
+            return ""
+        }
+        else if (self.scheduledOn.timeIntervalSinceNow < 5*60) {
+            return NSLocalizedString("Now", comment: "Time if now")
+        }
+        else {
+            let dateFormatter = NSDateFormatter()
+            dateFormatter.dateFormat = "HH:mm a"
+            return dateFormatter.stringFromDate(self.scheduledOn)
+        }
+    }
+}

--- a/BridgeAppSDK/SBABridgeInfo.swift
+++ b/BridgeAppSDK/SBABridgeInfo.swift
@@ -134,5 +134,9 @@ extension SBABridgeInfo {
         }
         return url
     }
+    
+    public func taskReferenceWithIdentifier(taskIdentifier: String) -> NSDictionary? {
+        return self.taskMap?.findObject({ $0.taskIdentifier == taskIdentifier})
+    }
 }
 

--- a/BridgeAppSDK/SBAExternalIDOnboardingController.swift
+++ b/BridgeAppSDK/SBAExternalIDOnboardingController.swift
@@ -37,7 +37,7 @@ import UIKit
  * Allow for any controller that implements this protocol to use the shared implementation for
  * registering a user via an external id rather than an email/password.
  */
-public protocol SBAExternalIDOnboardingController: class, SBAUIController, SBALoadingViewPresenter, SBAAlertPresenter, UITextFieldDelegate {
+public protocol SBAExternalIDOnboardingController: class, SBASharedInfoController, SBALoadingViewPresenter, SBAAlertPresenter, UITextFieldDelegate {
     
     // Text field that is used to enter the registration code
     var registrationCodeTextField: UITextField! { get }

--- a/BridgeAppSDK/SBASharedInfoController.swift
+++ b/BridgeAppSDK/SBASharedInfoController.swift
@@ -1,0 +1,52 @@
+//
+//  SBAUIController.swift
+//  BridgeAppSDK
+//
+//  Copyright © 2016 Sage Bionetworks. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification,
+// are permitted provided that the following conditions are met:
+//
+// 1.  Redistributions of source code must retain the above copyright notice, this
+// list of conditions and the following disclaimer.
+//
+// 2.  Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation and/or
+// other materials provided with the distribution.
+//
+// 3.  Neither the name of the copyright holder(s) nor the names of any contributors
+// may be used to endorse or promote products derived from this software without
+// specific prior written permission. No license is granted to the trademarks of
+// the copyright holders even if such marks are included in this software.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+
+import UIKit
+
+public protocol SBASharedInfoController {
+}
+
+extension SBASharedInfoController {
+    
+    public var sharedAppDelegate: SBASharedAppDelegate {
+        return UIApplication.sharedApplication().delegate as! SBASharedAppDelegate
+    }
+    
+    public var user: SBAUserWrapper {
+        return self.sharedAppDelegate.currentUser
+    }
+    
+    public var bridgeInfo: SBABridgeInfo {
+        return self.sharedAppDelegate.bridgeInfo
+    }
+}

--- a/BridgeAppSDK/SBASurveyFactory.swift
+++ b/BridgeAppSDK/SBASurveyFactory.swift
@@ -39,7 +39,7 @@ import BridgeSDK
  * that are not recognized by this factory and to allow usage by Obj-c classes that
  * do not recognize protocol extensions.
  */
-public class SBASurveyFactory : NSObject, SBAUIController {
+public class SBASurveyFactory : NSObject, SBASharedInfoController {
     
     public var steps: [ORKStep]?
     
@@ -79,8 +79,11 @@ public class SBASurveyFactory : NSObject, SBAUIController {
         return activeTask.createDefaultORKActiveTask(taskOptions)
     }
     
+    /**
+     * Factory method for creating an ORKTask from a given task reference Identifier
+     */
     public func createTaskWithTaskReference(taskIdentifier: String) -> ORKTask? {
-        guard let taskRef = self.bridgeInfo.taskMap?.findObject({ $0.taskIdentifier == taskIdentifier}) else {
+        guard let taskRef = self.bridgeInfo.taskReferenceWithIdentifier(taskIdentifier) else {
             return nil
         }
         return taskRef.transformToTask(self, isLastStep: true)

--- a/BridgeAppSDK/SBAUserBridgeManager.h
+++ b/BridgeAppSDK/SBAUserBridgeManager.h
@@ -68,8 +68,12 @@ typedef void (^SBAUserBridgeManagerCompletionBlock)(id _Nullable responseObject,
 
 + (void)ensureSignedInWithCompletion:(SBAUserBridgeManagerCompletionBlock _Nullable)completionBlock;
 
-+ (void) updateDataGroups:(NSArray<NSString *> *)dataGroups
-               completion:(SBAUserBridgeManagerCompletionBlock _Nullable)completionBlock;
++ (void)updateDataGroups:(NSArray<NSString *> *)dataGroups
+              completion:(SBAUserBridgeManagerCompletionBlock _Nullable)completionBlock;
+
++ (void)fetchChangesToScheduledActivities:(NSArray <SBBScheduledActivity *> *)scheduledActivities
+                                todayOnly:(BOOL)todayOnly
+                               completion:(SBAUserBridgeManagerCompletionBlock)completionBlock;
 
 @end
 

--- a/BridgeAppSDK/SBAUserBridgeManager.m
+++ b/BridgeAppSDK/SBAUserBridgeManager.m
@@ -152,4 +152,55 @@
      }];
 }
 
++ (void)fetchChangesToScheduledActivities:(NSArray <SBBScheduledActivity *> *)scheduledActivities
+                                todayOnly:(BOOL)todayOnly
+                               completion:(SBAUserBridgeManagerCompletionBlock)completionBlock
+{
+    // TODO: syoung 04/14/2016 - Erin Mounts: please replace stubbed out implement
+    
+    // Intended design is to allow for the server to win in getting updates to the current list of scheduled
+    // activities, but this will also *send* what is already known and may include a finishedOn date that is
+    // more recent than what is available from the server. syoung 04/14/2016
+    
+    id responseObject = scheduledActivities;
+    if (scheduledActivities.count == 0) {
+    
+        // Add in training
+        SBBScheduledActivity *training = [[SBBScheduledActivity alloc] init];
+        training.scheduledOn = [NSDate date];
+        training.guid = [NSUUID UUID].UUIDString;
+        training.activity = [[SBBActivity alloc] init];
+        training.activity.label = @"Training Session";
+        training.activity.labelDetail = @"15 minutes";
+        training.activity.task = [[SBBTaskReference alloc] init];
+        training.activity.task.identifier = @"1-Combo-295f81EF-13CB-4DB4-8223-10A173AA0780";
+    
+        // Add in medication tracker task
+        SBBScheduledActivity *medTracking = [[SBBScheduledActivity alloc] init];
+        medTracking.scheduledOn = [NSDate date];
+        medTracking.guid = [NSUUID UUID].UUIDString;
+        medTracking.activity = [[SBBActivity alloc] init];
+        medTracking.activity.label = @"Medication Tracker";
+        medTracking.activity.labelDetail = @"5 minutes";
+        medTracking.activity.task = [[SBBTaskReference alloc] init];
+        medTracking.activity.task.identifier = @"1-MedicationTracker-20EF8ED2-E461-4C20-9024-F43FCAAAF4C3";
+        
+        // Add in session 1
+        SBBScheduledActivity *activity1 = [[SBBScheduledActivity alloc] init];
+        activity1.scheduledOn = [NSDate dateWithTimeIntervalSinceNow: 2*60*60];
+        activity1.guid = [NSUUID UUID].UUIDString;
+        activity1.activity = [[SBBActivity alloc] init];
+        activity1.activity.label = @"Activity Session 1";
+        activity1.activity.labelDetail = @"15 minutes";
+        activity1.activity.task = [[SBBTaskReference alloc] init];
+        activity1.activity.task.identifier = @"1-Combo-295f81EF-13CB-4DB4-8223-10A173AA0780";
+        
+        responseObject = @[training, medTracking, activity1];
+    }
+    
+    dispatch_async(dispatch_get_main_queue(), ^{
+        completionBlock(responseObject, nil);
+    });
+}
+
 @end


### PR DESCRIPTION
I went ahead and moved the Activities view controller into BridgeAppSDK. This is not a complete implementation (does not include "keep going" section or handling of SBBSurvey objects or archiving and saving results for display in dashboard. (etc.) But it should give you an idea where I'm thinking the scheduling stuff could go and makes it easier us to implement concurrently.
