### PR TITLE
refactor

### DIFF
--- a/BridgeAppSDK/SBAUser.swift
+++ b/BridgeAppSDK/SBAUser.swift
@@ -308,7 +308,7 @@ extension SBAUser : SBBAuthManagerDelegateProtocol {
         self.sessionToken = sessionToken
     }
     
-    public func usernameForAuthManager(authManager: SBBAuthManagerProtocol?) -> String? {
+    public func emailForAuthManager(authManager: SBBAuthManagerProtocol?) -> String? {
         return self.email
     }
     

--- a/BridgeAppSDK/SBAUserBridgeManager.m
+++ b/BridgeAppSDK/SBAUserBridgeManager.m
@@ -69,15 +69,15 @@
      }];
 }
 
-+ (void)signIn:(NSString *)username password:(NSString *)password completion:(SBAUserBridgeManagerCompletionBlock _Nullable)completionBlock {
++ (void)signIn:(NSString *)email password:(NSString *)password completion:(SBAUserBridgeManagerCompletionBlock _Nullable)completionBlock {
     
-    NSParameterAssert(username);
+    NSParameterAssert(email);
     NSParameterAssert(password);
-    [SBBComponent(SBBAuthManager) signInWithUsername: username
-                                            password: password
-                                          completion:^(NSURLSessionDataTask * __unused task,
-                                                                 id responseObject,
-                                                                 NSError *error) {
+    [SBBComponent(SBBAuthManager) signInWithEmail: email
+                                         password: password
+                                       completion:^(NSURLSessionDataTask * __unused task,
+                                                    id responseObject,
+                                                    NSError *error) {
 #if DEBUG
         if (error != nil) {
             NSLog(@"Error with signup: %@", error);

--- a/BridgeAppSDK/SBAUserWrapper+Bridge.swift
+++ b/BridgeAppSDK/SBAUserWrapper+Bridge.swift
@@ -159,7 +159,7 @@ public extension SBAUserWrapper {
      * Verify registration to check that the user has verified their email address.
      */
     public func verifyRegistration(completion: ((NSError?) -> Void)?) {
-        guard let username = self.usernameForAuthManager?(nil), let password = self.passwordForAuthManager?(nil) else {
+        guard let username = self.emailForAuthManager?(nil), let password = self.passwordForAuthManager?(nil) else {
             assertionFailure("Attempting to login without a stored username and password")
             return
         }

--- a/BridgeAppSDKTests/SBAUserTests.swift
+++ b/BridgeAppSDKTests/SBAUserTests.swift
@@ -87,7 +87,7 @@ class MockAuthManager: NSObject, SBBAuthManagerProtocol {
         return NSURLSessionDataTask()
     }
     
-    func signInWithUsername(username: String, password: String, completion: SBBNetworkManagerCompletionBlock?) -> NSURLSessionDataTask {
+    func signInWithEmail(email: String, password: String, completion: SBBNetworkManagerCompletionBlock?) -> NSURLSessionDataTask {
         return NSURLSessionDataTask()
     }
     


### PR DESCRIPTION
sign in actually uses email--username is deprecated and must be equal to the email field if used--so let's refactor to reflect that. Requires https://github.com/Sage-Bionetworks/Bridge-iOS-SDK/pull/64
