### PR TITLE
BRIDGE-1279 Split the task results into subgroups by activity

### DIFF
--- a/BridgeAppSDK.xcodeproj/project.pbxproj
+++ b/BridgeAppSDK.xcodeproj/project.pbxproj
@@ -88,6 +88,9 @@
 		FF8DDFD61CB62280006D1AFA /* SBATrackedDataStore.m in Sources */ = {isa = PBXBuildFile; fileRef = FF8DDFD41CB62280006D1AFA /* SBATrackedDataStore.m */; };
 		FF8DDFE31CB63E92006D1AFA /* SBATrackedDataStoreTests.m in Sources */ = {isa = PBXBuildFile; fileRef = FF8DDFE21CB63E92006D1AFA /* SBATrackedDataStoreTests.m */; };
 		FF9055A11CE287BB0049D12A /* SBBScheduledActivity+Utilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF9055A01CE287BB0049D12A /* SBBScheduledActivity+Utilities.swift */; };
+		FF9055CA1CE3A8860049D12A /* CombinedTask.json in Resources */ = {isa = PBXBuildFile; fileRef = FF9055C91CE3A8860049D12A /* CombinedTask.json */; };
+		FF9055D91CE3B1880049D12A /* TappingTask.json in Resources */ = {isa = PBXBuildFile; fileRef = FF9055D81CE3B1880049D12A /* TappingTask.json */; };
+		FF9055DB1CE3E09C0049D12A /* NSUserDefaults+Utilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF9055DA1CE3E09C0049D12A /* NSUserDefaults+Utilities.swift */; };
 		FF9634C71C9A0A6600D07595 /* SBASurveyItem+Bridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF9634C61C9A0A6600D07595 /* SBASurveyItem+Bridge.swift */; };
 		FF9D4C3F1CA1FC28001C293C /* SBAAppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF9D4C3E1CA1FC28001C293C /* SBAAppDelegate.swift */; };
 		FF9D4C4C1CA20EAF001C293C /* HKHealthStore+Queries.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF9D4C4B1CA20EAF001C293C /* HKHealthStore+Queries.swift */; };
@@ -360,6 +363,9 @@
 		FF8DDFD41CB62280006D1AFA /* SBATrackedDataStore.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SBATrackedDataStore.m; sourceTree = "<group>"; };
 		FF8DDFE21CB63E92006D1AFA /* SBATrackedDataStoreTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SBATrackedDataStoreTests.m; sourceTree = "<group>"; };
 		FF9055A01CE287BB0049D12A /* SBBScheduledActivity+Utilities.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "SBBScheduledActivity+Utilities.swift"; sourceTree = "<group>"; };
+		FF9055C91CE3A8860049D12A /* CombinedTask.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = CombinedTask.json; sourceTree = "<group>"; };
+		FF9055D81CE3B1880049D12A /* TappingTask.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = TappingTask.json; sourceTree = "<group>"; };
+		FF9055DA1CE3E09C0049D12A /* NSUserDefaults+Utilities.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSUserDefaults+Utilities.swift"; sourceTree = "<group>"; };
 		FF9634C61C9A0A6600D07595 /* SBASurveyItem+Bridge.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "SBASurveyItem+Bridge.swift"; sourceTree = "<group>"; };
 		FF9D4C3E1CA1FC28001C293C /* SBAAppDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SBAAppDelegate.swift; sourceTree = "<group>"; };
 		FF9D4C4B1CA20EAF001C293C /* HKHealthStore+Queries.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "HKHealthStore+Queries.swift"; sourceTree = "<group>"; };
@@ -666,6 +672,7 @@
 				FB0C9EF21CAA52F700BA5B44 /* NSDate+Utilities.swift */,
 				FF23799E1CBC2E5900F3A943 /* NSDictionary+Utilities.swift */,
 				FFCF385C1CE1172A0090452F /* NSPredicate+Utilities.swift */,
+				FF9055DA1CE3E09C0049D12A /* NSUserDefaults+Utilities.swift */,
 				FF2498201CB6E605002DD05F /* SequenceType+Utilities.swift */,
 				FF6410F91CAF39B4007FB9E1 /* String+Utilities.swift */,
 				FBF1B6B21CAAF6FC007C1082 /* UIAlertController+Utilities.swift */,
@@ -718,7 +725,9 @@
 		FBC45E7B1C75B069007AA424 /* Test Files */ = {
 			isa = PBXGroup;
 			children = (
+				FF9055C91CE3A8860049D12A /* CombinedTask.json */,
 				FF6484161CB617790055B9E7 /* MedicationTracking.json */,
+				FF9055D81CE3B1880049D12A /* TappingTask.json */,
 			);
 			path = "Test Files";
 			sourceTree = "<group>";
@@ -1169,6 +1178,8 @@
 			buildActionMask = 2147483647;
 			files = (
 				FF6484171CB617790055B9E7 /* MedicationTracking.json in Resources */,
+				FF9055D91CE3B1880049D12A /* TappingTask.json in Resources */,
+				FF9055CA1CE3A8860049D12A /* CombinedTask.json in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1267,6 +1278,7 @@
 				FBC45E6D1C7531E3007AA424 /* SBAConsentDocumentFactory.swift in Sources */,
 				FFA8E4AF1CBD7CDA00ED5399 /* SBALoadingViewPresenter.swift in Sources */,
 				FFAAF5FD1CC00D7300500929 /* SBAActivityTableViewCell.swift in Sources */,
+				FF9055DB1CE3E09C0049D12A /* NSUserDefaults+Utilities.swift in Sources */,
 				FF3A429D1CC0B7E400B8623A /* SBATaskViewController.m in Sources */,
 				FFAAF6391CC0A42A00500929 /* SBABorderedButton.swift in Sources */,
 			);

--- a/BridgeAppSDK/NSUserDefaults+Utilities.swift
+++ b/BridgeAppSDK/NSUserDefaults+Utilities.swift
@@ -1,5 +1,5 @@
 //
-//  SBANotificationsManager.swift
+//  NSUserDefaults+Utilities.swift
 //  BridgeAppSDK
 //
 //  Copyright © 2016 Sage Bionetworks. All rights reserved.
@@ -31,38 +31,15 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //
 
-import UIKit
+import Foundation
 
-public class SBANotificationsManager: NSObject, SBASharedInfoController {
+public extension NSUserDefaults {
     
-    public static let sharedManager = SBANotificationsManager()
-    
-    public func setupNotificationsForScheduledActivities(activities: [SBBScheduledActivity]) {
-        // TODO: emm 2016-04-29 handle mPower-style notification scheduling, etc.
-        if !SBAPermissionsManager.sharedManager().isPermissionsGrantedForType(.LocalNotifications) {
-            return
+    public func flushUserDefaults() {
+        for (key, _) in self.dictionaryRepresentation() {
+            self.removeObjectForKey(key)
         }
-        
-        let app = UIApplication.sharedApplication()
-        app.cancelAllLocalNotifications()
-        
-        // Add a notification for the scheduled activities that should include one
-        for sa in activities {
-            if let taskRef = self.sharedBridgeInfo.taskReferenceForSchedule(sa)
-                where taskRef.scheduleNotification  {
-                let notif = UILocalNotification.init()
-                notif.fireDate = sa.scheduledOn
-                notif.soundName = UILocalNotificationDefaultSoundName
-                let format = Localization.localizedString("SBA_TIME_FOR_%@")
-                notif.alertBody = String(format: format, sa.activity.label)
-                app.scheduleLocalNotification(notif)
-            }
-        }
-        
-        // reschedule any notifications defined by the appDelegate
-        for notif in self.sharedAppDelegate.createLocalNotifications() {
-             app.scheduleLocalNotification(notif)
-        }
+        self.synchronize()
     }
-    
+
 }

--- a/BridgeAppSDK/SBAActivityTableViewController.swift
+++ b/BridgeAppSDK/SBAActivityTableViewController.swift
@@ -42,11 +42,26 @@ public class SBAActivityTableViewController: UITableViewController, SBAScheduled
     }
     private let _scheduledActivityManager : SBAScheduledActivityManager = SBAScheduledActivityManager()
     
+    private var foregroundNotification: NSObjectProtocol?
+    
     override public func viewWillAppear(animated: Bool) {
         super.viewWillAppear(animated)
         
         self.scheduledActivityManager.delegate = self
         self.scheduledActivityManager.reloadData()
+        
+        foregroundNotification = NSNotificationCenter.defaultCenter().addObserverForName(UIApplicationWillEnterForegroundNotification, object: nil, queue: NSOperationQueue.mainQueue()) {
+            [weak self] _ in
+            self?.scheduledActivityManager.reloadData()
+        }
+    }
+    
+    override public func viewWillDisappear(animated: Bool) {
+        super.viewWillDisappear(animated)
+        
+        if let notificationHandler = foregroundNotification {
+            NSNotificationCenter.defaultCenter().removeObserver(notificationHandler)
+        }
     }
     
     // MARK: data refresh

--- a/BridgeAppSDK/SBABridgeInfo.swift
+++ b/BridgeAppSDK/SBABridgeInfo.swift
@@ -72,9 +72,15 @@ public protocol SBABridgeInfo: class {
     var testUserDataGroup: String? { get }
     
     /**
+     * Mapping of schema identifier and associated info for creating an archive
+     */
+    var schemaMap: [NSDictionary]? { get }
+    
+    /**
      * Mapping of task identifier and associated info for creating a task
      */
     var taskMap: [NSDictionary]? { get }
+
 }
 
 public class SBABridgeInfoPList : NSObject, SBABridgeInfo {
@@ -85,11 +91,11 @@ public class SBABridgeInfoPList : NSObject, SBABridgeInfo {
     
     var plist: NSDictionary!
 
-    convenience override init() {
+    public convenience override init() {
         self.init(name: "BridgeInfo")!
     }
     
-    init?(name: String) {
+    public init?(name: String) {
         super.init()
         guard let plist = SBAResourceFinder().plistNamed(name) else {
             assertionFailure("\(name) plist file not found in the resource bundle")
@@ -123,6 +129,10 @@ public class SBABridgeInfoPList : NSObject, SBABridgeInfo {
     public var taskMap: [NSDictionary]? {
         return self.plist["taskMapping"] as? [NSDictionary]
     }
+    
+    public var schemaMap: [NSDictionary]? {
+        return self.plist["schemaMapping"] as? [NSDictionary]
+    }
 }
 
 extension SBABridgeInfo {
@@ -142,7 +152,11 @@ extension SBABridgeInfo {
         return url
     }
     
-    public func taskReferenceWithIdentifier(taskIdentifier: String) -> NSDictionary? {
+    public func schemaReferenceWithIdentifier(schemaIdentifier: String) -> SBASchemaReference? {
+        return self.schemaMap?.findObject({ $0.schemaIdentifier == schemaIdentifier})
+    }
+    
+    public func taskReferenceWithIdentifier(taskIdentifier: String) -> SBATaskReference? {
         return self.taskMap?.findObject({ $0.taskIdentifier == taskIdentifier})
     }
     

--- a/BridgeAppSDK/SBABridgeTask.swift
+++ b/BridgeAppSDK/SBABridgeTask.swift
@@ -40,6 +40,11 @@ public protocol SBATaskReference: class {
     var scheduleNotification: Bool { get }
 }
 
+public protocol SBASchemaReference: class {
+    var schemaIdentifier: String! { get }
+    var schemaRevision: NSNumber! { get }
+}
+
 public protocol SBABridgeTask: class {
     var taskIdentifier: String! { get }
     var schemaIdentifier: String! { get }

--- a/BridgeAppSDK/SBAExternalIDOnboardingController.swift
+++ b/BridgeAppSDK/SBAExternalIDOnboardingController.swift
@@ -63,7 +63,7 @@ public extension SBAExternalIDOnboardingController {
         registrationCodeTextField.resignFirstResponder()
         showLoadingView()
         
-        user.loginUser(externalId: text) { [weak self] error in
+        sharedUser.loginUser(externalId: text) { [weak self] error in
             if let error = error {
                 self?.hideLoadingView({
                     let title = NSLocalizedString("Registration Failed", comment: "Title for error when registration fails")

--- a/BridgeAppSDK/SBASharedInfoController.swift
+++ b/BridgeAppSDK/SBASharedInfoController.swift
@@ -42,11 +42,11 @@ extension SBASharedInfoController {
         return UIApplication.sharedApplication().delegate as! SBASharedAppDelegate
     }
     
-    public var user: SBAUserWrapper {
+    public var sharedUser: SBAUserWrapper {
         return self.sharedAppDelegate.currentUser
     }
     
-    public var bridgeInfo: SBABridgeInfo {
+    public var sharedBridgeInfo: SBABridgeInfo {
         return self.sharedAppDelegate.bridgeInfo
     }
 }

--- a/BridgeAppSDK/SBASubtaskStep.swift
+++ b/BridgeAppSDK/SBASubtaskStep.swift
@@ -72,15 +72,28 @@ public class SBASubtaskStep: ORKStep {
     func filteredTaskResult(inputResult: ORKTaskResult) -> ORKTaskResult {
         // create a mutated copy of the results that includes only the subtask results
         let subtaskResult: ORKTaskResult = inputResult.copy() as! ORKTaskResult
-        let prefix = "\(self.subtask.identifier)."
-        let predicate = NSPredicate(format: "identifier BEGINSWITH %@", prefix)
-        subtaskResult.results = subtaskResult.results?.filter() { predicate.evaluateWithObject($0) }
-        if let stepResults = subtaskResult.results {
-            for stepResult in stepResults {
-                stepResult.identifier = stepResult.identifier.substringFromIndex(prefix.endIndex)
-            }
+        if let stepResults = subtaskResult.results as? [ORKStepResult] {
+            let (subtaskResults, _) = filteredStepResults(stepResults)
+            subtaskResult.results = subtaskResults
         }
         return subtaskResult;
+    }
+    
+    func filteredStepResults(inputResults: [ORKStepResult]) -> (subtaskResults:[ORKStepResult], remainingResults:[ORKStepResult]) {
+        let prefix = "\(self.subtask.identifier)."
+        let predicate = NSPredicate(format: "identifier BEGINSWITH %@", prefix)
+        var subtaskResults:[ORKStepResult] = []
+        var remainingResults:[ORKStepResult] = []
+        for stepResult in inputResults {
+            if (predicate.evaluateWithObject(stepResult)) {
+                stepResult.identifier = stepResult.identifier.substringFromIndex(prefix.endIndex)
+                subtaskResults += [stepResult]
+            }
+            else {
+                remainingResults += [stepResult]
+            }
+        }
+        return (subtaskResults, remainingResults)
     }
     
     func stepWithIdentifier(identifier: String) -> ORKStep? {

--- a/BridgeAppSDK/SBASurveyItem+Dictionary.swift
+++ b/BridgeAppSDK/SBASurveyItem+Dictionary.swift
@@ -41,7 +41,7 @@ extension NSDictionary: SBAStepTransformer {
     public func transformToStep(factory: SBASurveyFactory, isLastStep: Bool) -> ORKStep? {
         if (self.surveyItemType.isNilType()) {
             guard let subtask = self.transformToTask(factory, isLastStep: isLastStep) else {
-                return ORKStep(identifier: self.schemaIdentifier)
+                return nil
             }
             let step = SBASubtaskStep(subtask: subtask)
             step.taskIdentifier = self.taskIdentifier

--- a/BridgeAppSDKTests/SBATrackedDataObjectTests.swift
+++ b/BridgeAppSDKTests/SBATrackedDataObjectTests.swift
@@ -87,7 +87,7 @@ class SBATrackedDataObjectTests: ResourceTestCase {
         
         guard let dataCollection = self.dataCollectionForMedicationTracking() else { return }
         
-        XCTAssertEqual(dataCollection.taskIdentifier, "1-APHMedicationTracker-20EF8ED2-E461-4C20-9024-F43FCAAAF4C3")
+        XCTAssertEqual(dataCollection.taskIdentifier, "Medication Task")
         XCTAssertEqual(dataCollection.schemaIdentifier, "Medication Tracker")
     }
     

--- a/BridgeAppSDKTests/SBAUserTests.swift
+++ b/BridgeAppSDKTests/SBAUserTests.swift
@@ -71,6 +71,7 @@ class MockBridgeInfo : NSObject, SBABridgeInfo {
     var passwordFormatForLoginViaExternalId: String?
     var testUserDataGroup: String?
     var taskMap: [NSDictionary]?
+    var schemaMap: [NSDictionary]?
 }
 
 class MockAuthManager: NSObject, SBBAuthManagerProtocol {

--- a/BridgeAppSDKTests/Test Files/CombinedTask.json
+++ b/BridgeAppSDKTests/Test Files/CombinedTask.json
@@ -1,0 +1,81 @@
+{
+    "taskIdentifier"    : "1-Combo-295f81EF-13CB-4DB4-8223-10A173AA0780",
+    "identifier"        : "Activity Session",
+    "taskSteps"         :
+    [
+     {
+     "identifier"   : "introduction",
+     "type"         : "instruction",
+     "title"        : "Activity Session",
+     "text"         : "A session includes four activities. It may take 5 minutes to complete.",
+     },
+     {
+     "resourceName"            : "MedicationTracking",
+     "resourceBundle"          : "org.sagebase.BridgeAppSDKTests",
+     "classType"               : "TrackedDataObjectCollection",
+     },
+     {
+     "taskIdentifier"            : "Tapping",
+     "schemaIdentifier"          : "Tapping Activity",
+     "taskType"                  : "tapping",
+     "intendedUseDescription"    : "In this activity we ask you to tap your fingers. It is an activity that tells us about your fine motor coordination.",
+     "localizedSteps"            : [{
+                                    "identifier" : "instruction1.right",
+                                    "detailText" : "Tap Next to begin."
+                                    },
+                                    {
+                                    "identifier" : "instruction1.left",
+                                    "detailText" : "Tap Next to begin."
+                                    }]
+     },
+     {
+     "taskIdentifier"            : "Voice",
+     "schemaIdentifier"          : "Voice Activity",
+     "taskType"                  : "voice",
+     "intendedUseDescription"    : "In this activity we ask you to say, “Aaaah.”",
+     "localizedSteps"            : [{
+                                     "identifier" : "instruction1",
+                                     "text"       : "This activity uses your phone’s microphone. Hold your phone so you can easily see the screen. Take a deep breath and say, “Aaaah,” for as long as you can. Try to keep the volume of your voice steady so the audio bars remain blue.",
+                                     "detailText" : "Tap Next to begin."
+                                    }]
+     },
+     {
+     "taskIdentifier"            : "Memory",
+     "schemaIdentifier"          : "Memory Activity",
+     "taskType"                  : "memory",
+     "intendedUseDescription"    : "In this activity we ask you to remember a pattern. It is an activity that tells us about your short-term memory.",
+     "localizedSteps"            : [{
+                                     "identifier" : "instruction1",
+                                     "text"       : "The flowers will light up one at a time. Watch carefully. Then tap the flowers in the same order they lit up.",
+                                     "detailText" : "Tap Next to begin."
+                                    }]
+     },
+     {
+     "taskIdentifier"            : "Walking",
+     "schemaIdentifier"          : "Walking Activity",
+     "taskType"                  : "walking",
+     "intendedUseDescription"    : "In this activity we ask you to walk back and forth. Then we ask you to turn in a full circle and stand still.",
+     "optional"                  : true,
+     "localizedSteps"            : [{
+                                    "identifier" : "instruction",
+                                    "detailText" : "This activity measures your gait and balance as you walk and stand still.\nIf you cannot safely walk unassisted, then tap the “Skip this activity” link in red below.  Otherwise, tap Next to begin."
+                                    },
+                                    {
+                                     "identifier" : "instruction1",
+                                     "text"       : "Find a place where you can walk safely back and forth in a straight line. Turn the volume on your phone all the way up.",
+                                     "detailText" : "Tap Next to begin.\nThen put the phone upside down in the front pocket of your pants and follow the audio instructions."
+                                    },
+                                    {
+                                     "identifier" : "walking.rest",
+                                     "finishedSpokenInstruction" : "You've completed the activity session.",
+                                    },
+                                    {
+                                     "identifier" : "conclusion",
+                                     "title"      : "Thank You!",
+                                     "text"       : "You’ve completed the activity session. Select done in top right hand corner.",
+                                     "detailText" : "",
+                                    },
+                                    ]
+     }
+     ]
+}

--- a/BridgeAppSDKTests/Test Files/MedicationTracking.json
+++ b/BridgeAppSDKTests/Test Files/MedicationTracking.json
@@ -1,5 +1,5 @@
 {
-    "taskIdentifier"    : "1-APHMedicationTracker-20EF8ED2-E461-4C20-9024-F43FCAAAF4C3",
+    "taskIdentifier"    : "Medication Task",
     "schemaIdentifier"  : "Medication Tracker",
     "itemsClassType"    : "Medication",
     "items": [

--- a/BridgeAppSDKTests/Test Files/TappingTask.json
+++ b/BridgeAppSDKTests/Test Files/TappingTask.json
@@ -1,0 +1,19 @@
+{
+     "taskIdentifier"            : "Tapping",
+     "schemaIdentifier"          : "Tapping Activity",
+     "taskType"                  : "tapping",
+     "intendedUseDescription"    : "In this activity we ask you to tap your fingers. It is an activity that tells us about your fine motor coordination.",
+     "localizedSteps"            : [{
+                                    "identifier" : "instruction1.right",
+                                    "detailText" : "Tap Next to begin."
+                                    },
+                                    {
+                                    "identifier" : "instruction1.left",
+                                    "detailText" : "Tap Next to begin."
+                                    }],
+    "insertSteps"               : [{
+                                   "resourceName"      : "MedicationTracking",
+                                   "resourceBundle"    : "org.sagebase.BridgeAppSDKTests",
+                                   "classType"         : "TrackedDataObjectCollection"
+                                   }]
+}


### PR DESCRIPTION
This only includes tests for cases where there is only one task result or where there are multiple results in the same activity. This does not include testing (yet) for the mPower app or for surveys from the server.
