### PR TITLE
Cleanup and fix to NSArray and NSDictionary implementation of jsonObject method

### DIFF
--- a/BridgeAppSDK/SBAJSONObject.h
+++ b/BridgeAppSDK/SBAJSONObject.h
@@ -46,6 +46,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
+id SBAJSONObjectForObject(id object);
+
 @protocol SBAJSONDictionaryRepresentableObject <NSObject>
 
 - (id)initWithDictionaryRepresentation:(NSDictionary *)dictionary;
@@ -54,15 +56,9 @@ NS_ASSUME_NONNULL_BEGIN
 @end
 
 @interface NSArray (SBAJSONObject) <SBAJSONObject>
-
-- (id)jsonObjectWithFormatterMap:(NSDictionary <NSString *, NSFormatter *> * _Nullable)formatterMap;
-
 @end
 
 @interface NSDictionary (SBAJSONObject) <SBAJSONObject>
-
-- (id)jsonObjectWithFormatterMap:(NSDictionary <NSString *, NSFormatter *> * _Nullable)formatterMap;
-
 @end
 
 @interface NSString (SBAJSONObject) <SBAJSONObject>
@@ -70,9 +66,6 @@ NS_ASSUME_NONNULL_BEGIN
 - (NSNumber * _Nullable)boolNumber;
 - (NSNumber * _Nullable)intNumber;
 
-@end
-
-@interface NSObject (SBAJSONObject) <SBAJSONObject>
 @end
 
 @interface NSNumber (SBAJSONObject) <SBAJSONObject>

--- a/BridgeAppSDK/SBAJSONObject.h
+++ b/BridgeAppSDK/SBAJSONObject.h
@@ -46,7 +46,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
-id SBAJSONObjectForObject(id object);
+id SBAJSONObjectForObject(id <NSObject> object);
 
 @protocol SBAJSONDictionaryRepresentableObject <NSObject>
 

--- a/BridgeAppSDK/SBAJSONObject.m
+++ b/BridgeAppSDK/SBAJSONObject.m
@@ -34,18 +34,6 @@
 #import "SBAJSONObject.h"
 @import BridgeSDK;
 
-@implementation NSObject (SBAJSONObject)
-
-- (id)jsonObject {
-    if ([self respondsToSelector:@selector(dictionaryRepresentation)]) {
-        return [[(id)self dictionaryRepresentation] jsonObject];
-    }
-    NSAssert(@"jsonObject method not implemented for class %@", NSStringFromClass([self class]));
-    return @{};
-}
-
-@end
-
 @implementation NSString (SBAJSONObject)
 
 - (id)jsonObject {
@@ -197,23 +185,27 @@
 
 @end
 
-id sba_JSONObjectForObject(id object, NSString * key, NSDictionary <NSString *, NSFormatter *> *formatterMap) {
-    if ([object respondsToSelector:@selector(jsonObjectWithFormatterMap:)]) {
-        return [object jsonObjectWithFormatterMap:formatterMap];
+id SBAJSONObjectForObject(id object) {
+    if (![object isKindOfClass:[NSObject class]]){
+        // If this is not an object that inherits from NSObject class then return NSNull
+        return [NSNull null];
+    }
+    else if ([object conformsToProtocol:@protocol(SBAJSONObject) ]) {
+        // If this is an objec that conforms to the jsonObject protocol then return that
+        return [object jsonObject];
     }
     else if ([object respondsToSelector:@selector(dictionaryRepresentation)]) {
+        // Otherwise, if this has a dictionary representation then return that
         NSDictionary *dictionary = [object dictionaryRepresentation];
         if ([NSJSONSerialization isValidJSONObject:dictionary]) {
             return dictionary;
         }
         else {
-            return [dictionary jsonObjectWithFormatterMap:formatterMap];
+            return [dictionary jsonObject];
         }
     }
-    else if ([object respondsToSelector:@selector(jsonObjectWithFormatter:)]) {
-        return [object jsonObjectWithFormatter:formatterMap[key]];
-    }
     else {
+        // Finally, drop through to the description
         return [object description];
     }
 }
@@ -221,16 +213,12 @@ id sba_JSONObjectForObject(id object, NSString * key, NSDictionary <NSString *, 
 @implementation NSArray (SBAJSONObject)
 
 - (id)jsonObject {
-    return [self jsonObjectWithFormatterMap:nil];
-}
 
-- (id)jsonObjectWithFormatterMap:(NSDictionary <NSString *, NSFormatter *> * _Nullable)formatterMap {
-    
     NSMutableArray *result = [NSMutableArray new];
     
     // Recursively convert objects to valid json objects
     for (id object in self) {
-        [result addObject:sba_JSONObjectForObject(object, nil, formatterMap)];
+        [result addObject:SBAJSONObjectForObject(object)];
     }
     
     return [result copy];
@@ -241,11 +229,7 @@ id sba_JSONObjectForObject(id object, NSString * key, NSDictionary <NSString *, 
 @implementation NSDictionary (SBAJSONObject)
 
 - (id)jsonObject {
-    return [self jsonObjectWithFormatterMap:nil];
-}
 
-- (id)jsonObjectWithFormatterMap:(NSDictionary <NSString *, NSFormatter *> * _Nullable)formatterMap {
-    
     NSMutableDictionary *result = [NSMutableDictionary new];
     
     // Recursively convert objects to valid json objects
@@ -256,7 +240,7 @@ id sba_JSONObjectForObject(id object, NSString * key, NSDictionary <NSString *, 
         id object = self[keyObject];
         
         // Set the value
-        result[key] = sba_JSONObjectForObject(object, key, formatterMap);
+        result[key] = SBAJSONObjectForObject(object);
     }
     
     return [result copy];

--- a/BridgeAppSDK/SBAJSONObject.m
+++ b/BridgeAppSDK/SBAJSONObject.m
@@ -185,18 +185,14 @@
 
 @end
 
-id SBAJSONObjectForObject(id object) {
-    if (![object isKindOfClass:[NSObject class]]){
-        // If this is not an object that inherits from NSObject class then return NSNull
-        return [NSNull null];
-    }
-    else if ([object conformsToProtocol:@protocol(SBAJSONObject) ]) {
+id SBAJSONObjectForObject(id <NSObject> object) {
+    if ([object conformsToProtocol:@protocol(SBAJSONObject) ]) {
         // If this is an objec that conforms to the jsonObject protocol then return that
-        return [object jsonObject];
+        return [(id <SBAJSONObject>)object jsonObject];
     }
     else if ([object respondsToSelector:@selector(dictionaryRepresentation)]) {
         // Otherwise, if this has a dictionary representation then return that
-        NSDictionary *dictionary = [object dictionaryRepresentation];
+        NSDictionary *dictionary = [(id)object dictionaryRepresentation];
         if ([NSJSONSerialization isValidJSONObject:dictionary]) {
             return dictionary;
         }
@@ -205,7 +201,8 @@ id SBAJSONObjectForObject(id object) {
         }
     }
     else {
-        // Finally, drop through to the description
+        // Finally, drop through to the description but throw an assert
+        NSAssert1(NO, @"jsonObject method not implemented for class %@", NSStringFromClass([object class]));
         return [object description];
     }
 }


### PR DESCRIPTION
Found a bug in the implementation of the NSArray and NSDictionary methods for jsonObject, plus the method with the key mapping was unnecessary with the current implementation.

I didn't want to push this to the shared branch b/c openssl requires about 1/2 hour to build. Therefore, I did not build and run unit tests, but thought this might be useful.
