### PR TITLE
Fix identifier for added selection result and use custom result type to allow key override

### DIFF
--- a/BridgeAppSDK.xcodeproj/project.pbxproj
+++ b/BridgeAppSDK.xcodeproj/project.pbxproj
@@ -80,6 +80,7 @@
 		FF45F84C1CA5D61900EE0562 /* SBAUserBridgeManager.m in Sources */ = {isa = PBXBuildFile; fileRef = FF45F84A1CA5D61900EE0562 /* SBAUserBridgeManager.m */; };
 		FF45F84E1CA5DBEF00EE0562 /* SBAUserWrapper+Bridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF45F84D1CA5DBEF00EE0562 /* SBAUserWrapper+Bridge.swift */; };
 		FF4F06881CEE3604007BD273 /* ORKFormStep+Result.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF4F06871CEE3604007BD273 /* ORKFormStep+Result.swift */; };
+		FF4F06D21CEED20D007BD273 /* SBATrackedDataResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF4F06D11CEED20D007BD273 /* SBATrackedDataResult.swift */; };
 		FF63D0CA1CCFF517007ADEE5 /* SBAWebViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF63D0C91CCFF517007ADEE5 /* SBAWebViewController.swift */; };
 		FF63D0F81CD032B4007ADEE5 /* SBALog.h in Headers */ = {isa = PBXBuildFile; fileRef = FF63D0F61CD032B4007ADEE5 /* SBALog.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		FF63D0F91CD032B4007ADEE5 /* SBALog.m in Sources */ = {isa = PBXBuildFile; fileRef = FF63D0F71CD032B4007ADEE5 /* SBALog.m */; };
@@ -447,6 +448,7 @@
 		FF45F84A1CA5D61900EE0562 /* SBAUserBridgeManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SBAUserBridgeManager.m; sourceTree = "<group>"; };
 		FF45F84D1CA5DBEF00EE0562 /* SBAUserWrapper+Bridge.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "SBAUserWrapper+Bridge.swift"; sourceTree = "<group>"; };
 		FF4F06871CEE3604007BD273 /* ORKFormStep+Result.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ORKFormStep+Result.swift"; sourceTree = "<group>"; };
+		FF4F06D11CEED20D007BD273 /* SBATrackedDataResult.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SBATrackedDataResult.swift; sourceTree = "<group>"; };
 		FF63D0C91CCFF517007ADEE5 /* SBAWebViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SBAWebViewController.swift; sourceTree = "<group>"; };
 		FF63D0F61CD032B4007ADEE5 /* SBALog.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SBALog.h; sourceTree = "<group>"; };
 		FF63D0F71CD032B4007ADEE5 /* SBALog.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SBALog.m; sourceTree = "<group>"; };
@@ -1141,6 +1143,7 @@
 				FFCF390D1CE26DE40090452F /* SBAActivityResult.h */,
 				FFCF390E1CE26DE40090452F /* SBAActivityResult.m */,
 				80D5F1D21CE557BA002A39DF /* ORKResult+SBAExtension.swift */,
+				FF4F06D11CEED20D007BD273 /* SBATrackedDataResult.swift */,
 			);
 			name = Result;
 			sourceTree = "<group>";
@@ -1486,6 +1489,7 @@
 			files = (
 				FF3A354E1CBDAFE600F44E6E /* UIColor+Utilities.swift in Sources */,
 				FB14FFE71C7686EB00E0D5AF /* SBAResourceFinder.swift in Sources */,
+				FF4F06D21CEED20D007BD273 /* SBATrackedDataResult.swift in Sources */,
 				FF24981F1CB6DC13002DD05F /* SBATrackedStep.swift in Sources */,
 				FF9D4C911CA32536001C293C /* SBAUser.swift in Sources */,
 				FBAD11671CADCFE5005611D0 /* SBATrackedDataObjectCollection.swift in Sources */,

--- a/BridgeAppSDK/SBATrackedDataObjectCollection.swift
+++ b/BridgeAppSDK/SBATrackedDataObjectCollection.swift
@@ -240,16 +240,14 @@ extension SBATrackedDataObjectCollection: SBABridgeTask, SBAStepTransformer, SBA
             return
         }
         
-        let resultIdentifier = "\(selectionItem).items"
-        
         // Create and return a step result for the consolidated steps
-        let questionResult = ORKChoiceQuestionResult(identifier: resultIdentifier)
-        questionResult.startDate = stepResult.startDate
-        questionResult.endDate = stepResult.endDate
-        questionResult.questionType = ORKQuestionType.MultipleChoice
-        questionResult.choiceAnswers = self.dataStore.selectedItems?.map({ $0.dictionaryRepresentation() })
+        let trackedResult = SBATrackedDataSelectionResult(identifier: selectionItem.identifier)
+        trackedResult.selectedItems = self.dataStore.selectedItems
+        trackedResult.startDate = stepResult.startDate
+        trackedResult.endDate = stepResult.endDate
+        trackedResult.questionText = selectionItem.textFormat ?? selectionItem.stepText
         
         // Add the consolidated result to the step results
-        stepResult.results = [firstResult, questionResult]
+        stepResult.results = [firstResult, trackedResult]
     }
 }

--- a/BridgeAppSDK/SBATrackedDataResult.swift
+++ b/BridgeAppSDK/SBATrackedDataResult.swift
@@ -1,0 +1,74 @@
+//
+//  SBATrackedDataResult.swift
+//  BridgeAppSDK
+//
+//  Copyright © 2016 Sage Bionetworks. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification,
+// are permitted provided that the following conditions are met:
+//
+// 1.  Redistributions of source code must retain the above copyright notice, this
+// list of conditions and the following disclaimer.
+//
+// 2.  Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation and/or
+// other materials provided with the distribution.
+//
+// 3.  Neither the name of the copyright holder(s) nor the names of any contributors
+// may be used to endorse or promote products derived from this software without
+// specific prior written permission. No license is granted to the trademarks of
+// the copyright holders even if such marks are included in this software.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+
+import UIKit
+
+public class SBATrackedDataSelectionResult: ORKQuestionResult {
+    
+    public var selectedItems: [SBATrackedDataObject]?
+    
+    public override init(identifier: String) {
+        super.init(identifier: identifier)
+        self.questionType = .MultipleChoice
+    }
+    
+    public required init?(coder aDecoder: NSCoder) {
+        super.init(coder: aDecoder)
+        self.selectedItems = aDecoder.decodeObjectForKey("selectedItems") as? [SBATrackedDataObject]
+    }
+    
+    public override func encodeWithCoder(aCoder: NSCoder) {
+        super.encodeWithCoder(aCoder)
+        aCoder.encodeObject(self.selectedItems, forKey: "selectedItems")
+    }
+    
+    public override func isEqual(object: AnyObject?) -> Bool {
+        guard super.isEqual(object), let obj = object as? SBATrackedDataSelectionResult else { return false }
+        if let itemsA = self.selectedItems, let itemsB = obj.selectedItems {
+            return itemsA == itemsB
+        }
+        else {
+            return (self.selectedItems == nil) && (obj.selectedItems == nil)
+        }
+    }
+
+}
+
+extension SBATrackedDataSelectionResult {
+    
+    public override func jsonSerializedAnswer() -> AnswerKeyAndValue? {
+        guard let selectedItems = self.selectedItems else { return nil }
+        return AnswerKeyAndValue(key: "items", value: (selectedItems as NSArray).jsonObject())
+    }
+    
+}

--- a/BridgeAppSDK/SBATrackedStep.swift
+++ b/BridgeAppSDK/SBATrackedStep.swift
@@ -322,7 +322,7 @@ public class SBATrackedFormStep: ORKFormStep {
         }
         
         let answerFormat = ORKTextChoiceAnswerFormat(style: .MultipleChoice, textChoices: choices)
-        let formItem = ORKFormItem(identifier: self.identifier, text: nil, answerFormat: answerFormat)
+        let formItem = ORKFormItem(identifier: self.identifier + ".choices", text: nil, answerFormat: answerFormat)
         self.formItems = [formItem]
     }
     

--- a/BridgeAppSDKTests/SBATrackedDataObjectTests.swift
+++ b/BridgeAppSDKTests/SBATrackedDataObjectTests.swift
@@ -769,20 +769,22 @@ class SBATrackedDataObjectTests: ResourceTestCase {
     
     func checkSelectionItemsInserted(selectedItems: [SBATrackedDataObject], taskResult: ORKTaskResult) {
         // Check that the task result includes items
-        guard let selectionStepResults = taskResult.stepResultForStepIdentifier("medicationSelection")?.results
+        guard let selectionStepResults = taskResult.stepResultForStepIdentifier("medicationSelection")?.results,
+            let lastResult = selectionStepResults.last
             else {
                 XCTAssert(false, "Selection step results not found in \(taskResult)")
                 return
         }
         
         XCTAssertEqual(selectionStepResults.count, 2)
-        guard let resultItems = (selectionStepResults.last as? ORKChoiceQuestionResult)?.choiceAnswers as? [[NSObject : AnyObject]] else {
-            XCTAssert(false, "Selection step results do not match expected \(selectionStepResults)")
+        guard let formResult = lastResult as? SBATrackedDataSelectionResult,
+            let resultItems = formResult.selectedItems else {
+            XCTAssert(false, "Selection step results do not match expected \(lastResult)")
             return
         }
         
-        let dictionaryItems = selectedItems.map { $0.dictionaryRepresentation() }
-        XCTAssertEqual(resultItems, dictionaryItems)
+        XCTAssertEqual(resultItems, selectedItems)
+        XCTAssertEqual(formResult.identifier, "medicationSelection")
     }
     
     // Mark: convenience methods


### PR DESCRIPTION
mPower already has an implementation that assumes the schema is setup with "items" as the keyword for the selected medication rather than "choiceAnswers".
