### PR TITLE
Refactor the activity timing for tracking each item

### DIFF
--- a/BridgeAppSDK.xcodeproj/project.pbxproj
+++ b/BridgeAppSDK.xcodeproj/project.pbxproj
@@ -72,7 +72,6 @@
 		FF45F84B1CA5D61900EE0562 /* SBAUserBridgeManager.h in Headers */ = {isa = PBXBuildFile; fileRef = FF45F8491CA5D61900EE0562 /* SBAUserBridgeManager.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		FF45F84C1CA5D61900EE0562 /* SBAUserBridgeManager.m in Sources */ = {isa = PBXBuildFile; fileRef = FF45F84A1CA5D61900EE0562 /* SBAUserBridgeManager.m */; };
 		FF45F84E1CA5DBEF00EE0562 /* SBAUserWrapper+Bridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF45F84D1CA5DBEF00EE0562 /* SBAUserWrapper+Bridge.swift */; };
-		FF4F06881CEE3604007BD273 /* ORKFormStep+Result.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF4F06871CEE3604007BD273 /* ORKFormStep+Result.swift */; };
 		FF4F06D21CEED20D007BD273 /* SBATrackedDataResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF4F06D11CEED20D007BD273 /* SBATrackedDataResult.swift */; };
 		FF4F06E81CEF7DE5007BD273 /* SBASubtaskStepTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF4F06E71CEF7DE5007BD273 /* SBASubtaskStepTests.swift */; };
 		FF63D0CA1CCFF517007ADEE5 /* SBAWebViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF63D0C91CCFF517007ADEE5 /* SBAWebViewController.swift */; };
@@ -154,6 +153,8 @@
 		FFAAF61F1CC0267E00500929 /* SBAPermissionsManager.m in Sources */ = {isa = PBXBuildFile; fileRef = FFAAF61D1CC0267E00500929 /* SBAPermissionsManager.m */; };
 		FFAAF6221CC03B2300500929 /* SBATaskReminderManagerProtocol.h in Headers */ = {isa = PBXBuildFile; fileRef = FFAAF6211CC03B2300500929 /* SBATaskReminderManagerProtocol.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		FFAAF6391CC0A42A00500929 /* SBABorderedButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFAAF6381CC0A42A00500929 /* SBABorderedButton.swift */; };
+		FFB30D2E1D4008DE00D175D2 /* Array+Utilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFB30D2D1D4008DE00D175D2 /* Array+Utilities.swift */; };
+		FFB30D621D40891400D175D2 /* ORKFormStep+Result.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFB30D611D40891400D175D2 /* ORKFormStep+Result.swift */; };
 		FFBB57261CACEAA00041F120 /* SBAActiveTask+Dictionary.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFBB57251CACEAA00041F120 /* SBAActiveTask+Dictionary.swift */; };
 		FFBB57311CACEADF0041F120 /* SBAActiveTaskTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFBB57301CACEADF0041F120 /* SBAActiveTaskTests.swift */; };
 		FFC15FD11CFE439500C29AF7 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = FFC15FD31CFE439500C29AF7 /* Main.storyboard */; };
@@ -177,6 +178,7 @@
 		FFCF38501CE113FC0090452F /* SBBScheduledActivity+Filters.m in Sources */ = {isa = PBXBuildFile; fileRef = FFCF384E1CE113FC0090452F /* SBBScheduledActivity+Filters.m */; };
 		FFCF385D1CE1172A0090452F /* NSPredicate+Utilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFCF385C1CE1172A0090452F /* NSPredicate+Utilities.swift */; };
 		FFCF39101CE26DE40090452F /* SBAActivityResult.m in Sources */ = {isa = PBXBuildFile; fileRef = FFCF390E1CE26DE40090452F /* SBAActivityResult.m */; };
+		FFDA29EF1D3FF216005CD0D0 /* SBATrackedActivityStep.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFDA29EE1D3FF216005CD0D0 /* SBATrackedActivityStep.swift */; };
 		FFDDD7F01D2DA02B00446806 /* SBAConsentReviewOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFDDD7EF1D2DA02B00446806 /* SBAConsentReviewOptions.swift */; };
 		FFDECDB71D07317B00434001 /* SBAOnboardingManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFDECDB61D07317B00434001 /* SBAOnboardingManager.swift */; };
 		FFDECDC81D07434C00434001 /* StudyOverviewViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFDECDC71D07434C00434001 /* StudyOverviewViewController.swift */; };
@@ -427,7 +429,6 @@
 		FF45F8491CA5D61900EE0562 /* SBAUserBridgeManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SBAUserBridgeManager.h; sourceTree = "<group>"; };
 		FF45F84A1CA5D61900EE0562 /* SBAUserBridgeManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SBAUserBridgeManager.m; sourceTree = "<group>"; };
 		FF45F84D1CA5DBEF00EE0562 /* SBAUserWrapper+Bridge.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "SBAUserWrapper+Bridge.swift"; sourceTree = "<group>"; };
-		FF4F06871CEE3604007BD273 /* ORKFormStep+Result.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ORKFormStep+Result.swift"; sourceTree = "<group>"; };
 		FF4F06D11CEED20D007BD273 /* SBATrackedDataResult.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SBATrackedDataResult.swift; sourceTree = "<group>"; };
 		FF4F06E71CEF7DE5007BD273 /* SBASubtaskStepTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SBASubtaskStepTests.swift; sourceTree = "<group>"; };
 		FF63D0C91CCFF517007ADEE5 /* SBAWebViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SBAWebViewController.swift; sourceTree = "<group>"; };
@@ -515,6 +516,8 @@
 		FFAAF61D1CC0267E00500929 /* SBAPermissionsManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SBAPermissionsManager.m; sourceTree = "<group>"; };
 		FFAAF6211CC03B2300500929 /* SBATaskReminderManagerProtocol.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SBATaskReminderManagerProtocol.h; sourceTree = "<group>"; };
 		FFAAF6381CC0A42A00500929 /* SBABorderedButton.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SBABorderedButton.swift; sourceTree = "<group>"; };
+		FFB30D2D1D4008DE00D175D2 /* Array+Utilities.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Array+Utilities.swift"; sourceTree = "<group>"; };
+		FFB30D611D40891400D175D2 /* ORKFormStep+Result.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ORKFormStep+Result.swift"; sourceTree = "<group>"; };
 		FFBB57251CACEAA00041F120 /* SBAActiveTask+Dictionary.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "SBAActiveTask+Dictionary.swift"; sourceTree = "<group>"; };
 		FFBB57301CACEADF0041F120 /* SBAActiveTaskTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SBAActiveTaskTests.swift; sourceTree = "<group>"; };
 		FFC15FD21CFE439500C29AF7 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
@@ -535,6 +538,7 @@
 		FFCF385C1CE1172A0090452F /* NSPredicate+Utilities.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSPredicate+Utilities.swift"; sourceTree = "<group>"; };
 		FFCF390D1CE26DE40090452F /* SBAActivityResult.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SBAActivityResult.h; sourceTree = "<group>"; };
 		FFCF390E1CE26DE40090452F /* SBAActivityResult.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SBAActivityResult.m; sourceTree = "<group>"; };
+		FFDA29EE1D3FF216005CD0D0 /* SBATrackedActivityStep.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SBATrackedActivityStep.swift; sourceTree = "<group>"; };
 		FFDDD7EF1D2DA02B00446806 /* SBAConsentReviewOptions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SBAConsentReviewOptions.swift; sourceTree = "<group>"; };
 		FFDECDB61D07317B00434001 /* SBAOnboardingManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SBAOnboardingManager.swift; sourceTree = "<group>"; };
 		FFDECDC71D07434C00434001 /* StudyOverviewViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StudyOverviewViewController.swift; sourceTree = "<group>"; };
@@ -685,6 +689,7 @@
 		801040C11C5A843D00D26E19 /* BridgeAppSDKTests */ = {
 			isa = PBXGroup;
 			children = (
+				FFB30D631D40891900D175D2 /* Utilities */,
 				FBC45E7B1C75B069007AA424 /* Test Files */,
 				FBE5515A1C6D265000C9E1AA /* MockObjects */,
 				801040C41C5A843D00D26E19 /* Info.plist */,
@@ -812,6 +817,7 @@
 		FBAE3CE61C86157E003CEC4A /* Utilities */ = {
 			isa = PBXGroup;
 			children = (
+				FFB30D2D1D4008DE00D175D2 /* Array+Utilities.swift */,
 				FFDECE001D07DDED00434001 /* Dictionary+Utilities.swift */,
 				FF3A354D1CBDAFE600F44E6E /* UIColor+Utilities.swift */,
 				FFA8E4A91CBD6E0B00ED5399 /* NSError+SBBTranslation.swift */,
@@ -904,6 +910,7 @@
 				FB84392C1C7518FE0086E961 /* SBATextChoice.swift */,
 				FF24981E1CB6DC13002DD05F /* SBATrackedStep.swift */,
 				FF9055EB1CE527890049D12A /* SBAProgressStep.swift */,
+				FFDA29EE1D3FF216005CD0D0 /* SBATrackedActivityStep.swift */,
 			);
 			name = Step;
 			sourceTree = "<group>";
@@ -1053,7 +1060,6 @@
 				FF9055DD1CE501290049D12A /* ResearchKitExtensions.h */,
 				FFCF37B01CD94EC80090452F /* ORKOrderedTask+SBAExtension.h */,
 				FFCF37B11CD94EC80090452F /* ORKOrderedTask+SBAExtension.m */,
-				FF4F06871CEE3604007BD273 /* ORKFormStep+Result.swift */,
 				FF80920E1D01FD35003FF617 /* ORKAnswerFormat+KeyboardUtilities.swift */,
 				FF10F4DD1D244ACE005C9BB4 /* ORKCollectionResult+SBAExtensions.h */,
 				FF10F4DE1D244ACE005C9BB4 /* ORKCollectionResult+SBAExtensions.m */,
@@ -1129,6 +1135,14 @@
 				FFCF37DF1CDA99120090452F /* UIView+LayoutExtensions.swift */,
 			);
 			name = Views;
+			sourceTree = "<group>";
+		};
+		FFB30D631D40891900D175D2 /* Utilities */ = {
+			isa = PBXGroup;
+			children = (
+				FFB30D611D40891400D175D2 /* ORKFormStep+Result.swift */,
+			);
+			name = Utilities;
 			sourceTree = "<group>";
 		};
 		FFC15FAF1CFE3DB300C29AF7 /* Apple Sample Code */ = {
@@ -1646,6 +1660,7 @@
 				FB8439191C727BEB0086E961 /* SBASurveyFactory.swift in Sources */,
 				FF9E48961CF3A2F1005EE7E0 /* StaticUtilities.swift in Sources */,
 				FFDDD7F01D2DA02B00446806 /* SBAConsentReviewOptions.swift in Sources */,
+				FFDA29EF1D3FF216005CD0D0 /* SBATrackedActivityStep.swift in Sources */,
 				FB84392F1C7519340086E961 /* SBASurveyItem.swift in Sources */,
 				FFCF38501CE113FC0090452F /* SBBScheduledActivity+Filters.m in Sources */,
 				FB14FFE91C769F9E00E0D5AF /* SBAConsentSharingOptions.swift in Sources */,
@@ -1662,6 +1677,7 @@
 				FFDECE041D088FA600434001 /* SBALoginStep.swift in Sources */,
 				FFAAF5FB1CC00CF100500929 /* SBAActivityTableViewController.swift in Sources */,
 				FF10F4E01D244ACE005C9BB4 /* ORKCollectionResult+SBAExtensions.m in Sources */,
+				FFB30D2E1D4008DE00D175D2 /* Array+Utilities.swift in Sources */,
 				FF9634C71C9A0A6600D07595 /* SBASurveyItem+Bridge.swift in Sources */,
 				FBAD115A1CADB2F0005611D0 /* SBADataObject.m in Sources */,
 				80D5F1D31CE557BA002A39DF /* ORKResult+SBAExtension.swift in Sources */,
@@ -1687,7 +1703,6 @@
 				FFDECE0A1D08D0F600434001 /* SBAProfileInfoForm.swift in Sources */,
 				FFAAF61F1CC0267E00500929 /* SBAPermissionsManager.m in Sources */,
 				FBE551691C6D9CBC00C9E1AA /* SBASurveyNavigationStep.swift in Sources */,
-				FF4F06881CEE3604007BD273 /* ORKFormStep+Result.swift in Sources */,
 				FFDECDF81D0758C700434001 /* SBAOnboardingSection.swift in Sources */,
 				FFDECE061D08901300434001 /* SBAEmailVerificationStep.swift in Sources */,
 				80D5F1981CE532C2002A39DF /* SBAEncryptionHelper.swift in Sources */,
@@ -1733,6 +1748,7 @@
 				FF8997791D0B585600B26051 /* MockBridgeInfo.m in Sources */,
 				FBE5515D1C6D267100C9E1AA /* MockORKTask.m in Sources */,
 				FF2498141CB6C1F0002DD05F /* MockTrackedDataStore.m in Sources */,
+				FFB30D621D40891400D175D2 /* ORKFormStep+Result.swift in Sources */,
 				FFCB98871CAC9000005078EF /* DeprecationTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/BridgeAppSDK/Array+Utilities.swift
+++ b/BridgeAppSDK/Array+Utilities.swift
@@ -1,0 +1,45 @@
+//
+//  Array+Utilities.swift
+//  BridgeAppSDK
+//
+//  Copyright © 2016 Sage Bionetworks. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification,
+// are permitted provided that the following conditions are met:
+//
+// 1.  Redistributions of source code must retain the above copyright notice, this
+// list of conditions and the following disclaimer.
+//
+// 2.  Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation and/or
+// other materials provided with the distribution.
+//
+// 3.  Neither the name of the copyright holder(s) nor the names of any contributors
+// may be used to endorse or promote products derived from this software without
+// specific prior written permission. No license is granted to the trademarks of
+// the copyright holders even if such marks are included in this software.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+
+import Foundation
+
+extension Array where Element: Equatable {
+    
+    @warn_unused_result
+    public func nextMatch(object: Array.Generator.Element?) -> Array.Generator.Element? {
+        guard let match = object else { return self.first }
+        return self.nextObject({ (match == $0)
+        })
+    }
+
+}

--- a/BridgeAppSDK/SBASurveyFactory.swift
+++ b/BridgeAppSDK/SBASurveyFactory.swift
@@ -161,13 +161,6 @@ public class SBASurveyFactory : NSObject, SBASharedInfoController {
         return createSurveyStepWithCustomType(inputItem)
     }
     
-    final func createSurveyStep(inputItem: SBATrackedStepSurveyItem, trackedItems: [SBATrackedDataObject]) -> ORKStep? {
-        guard let trackingType = inputItem.trackingType where trackingType.isTrackedFormStepType() else {
-            return self.createSurveyStep(inputItem)
-        }
-        return SBATrackedFormStep(surveyItem: inputItem, items: trackedItems)
-    }
-    
 }
 
 extension SBASurveyItem {

--- a/BridgeAppSDK/SBATrackedActivityStep.swift
+++ b/BridgeAppSDK/SBATrackedActivityStep.swift
@@ -65,8 +65,7 @@ extension SBATrackedActivitySurveyItem {
                 guard item.tracking else { return nil }
                 return baseStep.copyWithIdentifier(item.identifier)
             })
-            let task = ORKOrderedTask(identifier: self.identifier, steps: steps)
-            return SBATrackedActivityPageStep(identifier: self.identifier, pageTask: task)
+            return SBATrackedActivityPageStep(identifier: self.identifier, steps: steps)
             
         }
         else {
@@ -144,8 +143,8 @@ public class SBATrackedActivityPageStep: ORKPageStep, SBATrackedNavigationStep {
     
     private var selectedItemIdentifiers: [String] = []
     
-    override public init(identifier: String, pageTask task: ORKOrderedTask) {
-        super.init(identifier: identifier, pageTask: task)
+    override init(identifier: String, steps: [ORKStep]?) {
+        super.init(identifier: identifier, steps: steps)
     }
     
     override public func stepViewControllerClass() -> AnyClass {
@@ -214,7 +213,7 @@ public class SBATrackedActivityPageStep: ORKPageStep, SBATrackedNavigationStep {
     
     public init(identifier: String) {
         // Copying requires defining the base class ORKStep init
-        super.init(identifier: identifier, pageTask: ORKOrderedTask(identifier: identifier, steps: nil))
+        super.init(identifier: identifier, steps: nil)
     }
     
     override public func copyWithZone(zone: NSZone) -> AnyObject {

--- a/BridgeAppSDK/SBATrackedActivityStep.swift
+++ b/BridgeAppSDK/SBATrackedActivityStep.swift
@@ -1,0 +1,273 @@
+//
+//  SBATrackedActivityStep.swift
+//  BridgeAppSDK
+//
+//  Copyright © 2016 Sage Bionetworks. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification,
+// are permitted provided that the following conditions are met:
+//
+// 1.  Redistributions of source code must retain the above copyright notice, this
+// list of conditions and the following disclaimer.
+//
+// 2.  Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation and/or
+// other materials provided with the distribution.
+//
+// 3.  Neither the name of the copyright holder(s) nor the names of any contributors
+// may be used to endorse or promote products derived from this software without
+// specific prior written permission. No license is granted to the trademarks of
+// the copyright holders even if such marks are included in this software.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+
+import ResearchKit
+
+public protocol SBATrackedActivitySurveyItem: SBAFormStepSurveyItem, SBATrackedStep {
+    var trackEach: Bool { get }
+    var textFormat: String? { get }
+}
+
+extension NSDictionary: SBATrackedActivitySurveyItem {
+    
+    public var textFormat: String? {
+        return self["textFormat"] as? String
+    }
+    
+    public var trackEach: Bool {
+        return self["trackEach"] as? Bool ?? false
+    }
+}
+
+extension SBATrackedActivitySurveyItem {
+    
+    public func createTrackedActivityStep(items:[SBATrackedDataObject]) -> ORKStep {
+        
+        // Create a base form step
+        let baseStep = SBATrackedActivityFormStep(identifier: self.identifier)
+        baseStep.textFormat = self.textFormat
+        self.mapStepValues(baseStep)
+        self.buildFormItems(baseStep, isSubtaskStep: false)
+        
+        if (self.trackEach) {
+            // If tracking each then need to create a step for each item that is tracked
+            let steps = items.mapAndFilter({ (item) -> SBATrackedActivityFormStep? in
+                guard item.tracking else { return nil }
+                return baseStep.copyWithIdentifier(item.identifier)
+            })
+            let task = ORKOrderedTask(identifier: self.identifier, steps: steps)
+            return SBATrackedActivityPageStep(identifier: self.identifier, pageTask: task)
+            
+        }
+        else {
+            // If using a consolidated form step, then just return the one step
+            return baseStep
+        }
+    }
+}
+
+public class SBATrackedActivityFormStep: ORKFormStep, SBATrackedNavigationStep {
+    
+    var textFormat: String?
+    
+    public override init(identifier: String) {
+        super.init(identifier: identifier)
+    }
+    
+    // MARK: SBATrackedNavigationStep
+    
+    public var trackingType: SBATrackingStepType? {
+        return .activity
+    }
+    
+    public var shouldSkipStep: Bool {
+        return _shouldSkipStep
+    }
+    var _shouldSkipStep: Bool = false
+    
+    public func update(selectedItems selectedItems:[SBATrackedDataObject]) {
+        // filter out selected items that are not tracked
+        let trackedItems = selectedItems.filter({ $0.tracking })
+        _shouldSkipStep = (trackedItems.count == 0)
+        if let textFormat = self.textFormat where (trackedItems.count > 0) {
+            let shortText = Localization.localizedJoin(trackedItems.map({ $0.shortText}))
+            self.text = String.localizedStringWithFormat(textFormat, shortText)
+        }
+    }
+    
+    // MARK: NSCoding
+    
+    required public init(coder aDecoder: NSCoder) {
+        super.init(coder: aDecoder)
+        self.textFormat = aDecoder.decodeObjectForKey("textFormat") as? String
+    }
+    
+    override public func encodeWithCoder(aCoder: NSCoder) {
+        super.encodeWithCoder(aCoder)
+        aCoder.encodeObject(self.textFormat, forKey: "textFormat")
+    }
+    
+    // MARK: NSCopying
+    
+    override public func copyWithZone(zone: NSZone) -> AnyObject {
+        let copy = super.copyWithZone(zone) as! SBATrackedActivityFormStep
+        copy.textFormat = self.textFormat
+        return copy
+    }
+    
+    // MARK: Equality
+
+    override public func isEqual(object: AnyObject?) -> Bool {
+        guard let object = object as? SBATrackedActivityFormStep else { return false }
+        return super.isEqual(object) &&
+            object.textFormat == self.textFormat
+    }
+    
+    override public var hash: Int {
+        return super.hash ^
+            SBAObjectHash(self.textFormat)
+    }
+    
+}
+
+public class SBATrackedActivityPageStep: ORKPageStep, SBATrackedNavigationStep {
+    
+    private var selectedItemIdentifiers: [String] = []
+    
+    override public init(identifier: String, pageTask task: ORKOrderedTask) {
+        super.init(identifier: identifier, pageTask: task)
+    }
+    
+    override public func stepViewControllerClass() -> AnyClass {
+        return SBATrackedActivityPageStepViewController.classForCoder()
+    }
+    
+    // MARK: Navigation override
+    
+    override public func stepAfterStepWithIdentifier(identifier: String?, withResult result: ORKTaskResult) -> ORKStep? {
+        // If this step should be skipped then there are no valid steps to display
+        if shouldSkipStep { return nil }
+        
+        // Look for the next match
+        guard let nextIdentifier = selectedItemIdentifiers.nextMatch(identifier) else { return nil }
+        return pageTask.stepWithIdentifier(nextIdentifier)
+    }
+    
+    override public func stepBeforeStepWithIdentifier(identifier: String, withResult result: ORKTaskResult) -> ORKStep? {
+        // If this step should be skipped then there are no valid steps to display
+        if shouldSkipStep { return nil }
+        
+        // Look in reverse order through the selected identifiers
+        guard let nextIdentifier = selectedItemIdentifiers.reverse().nextMatch(identifier) else { return nil }
+        return pageTask.stepWithIdentifier(nextIdentifier)
+    }
+    
+    // MARK: SBATrackedNavigationStep
+    
+    public var trackingType: SBATrackingStepType? {
+        return .activity
+    }
+    
+    public var shouldSkipStep: Bool {
+        return selectedItemIdentifiers.count == 0
+    }
+    
+    public func update(selectedItems selectedItems:[SBATrackedDataObject]) {
+    
+        // filter out selected items that are not tracked
+        let trackedItems = selectedItems.filter({ $0.tracking })
+        
+        // update the selectedIdentifiers
+        selectedItemIdentifiers = trackedItems.map({ $0.identifier })
+        
+        // update the underlying form steps
+        for item in trackedItems {
+            if let step = self.stepWithIdentifier(item.identifier) as? SBATrackedActivityFormStep {
+                step.update(selectedItems: [item])
+            }
+        }
+    }
+    
+    // MARK: NSCoding
+    
+    required public init(coder aDecoder: NSCoder) {
+        super.init(coder: aDecoder)
+        self.selectedItemIdentifiers = aDecoder.decodeObjectForKey("selectedItemIdentifiers") as? [String] ?? []
+    }
+    
+    override public func encodeWithCoder(aCoder: NSCoder) {
+        super.encodeWithCoder(aCoder)
+        aCoder.encodeObject(self.selectedItemIdentifiers, forKey: "selectedItemIdentifiers")
+    }
+    
+    // MARK: NSCopying
+    
+    public init(identifier: String) {
+        // Copying requires defining the base class ORKStep init
+        super.init(identifier: identifier, pageTask: ORKOrderedTask(identifier: identifier, steps: nil))
+    }
+    
+    override public func copyWithZone(zone: NSZone) -> AnyObject {
+        let copy = super.copyWithZone(zone) as! SBATrackedActivityPageStep
+        copy.selectedItemIdentifiers = self.selectedItemIdentifiers
+        return copy
+    }
+    
+    // MARK: Equality
+    
+    // syoung 07/20/2016 Equality does not depend upon the selectedItemIdentifiers being the same
+    // This is a tracking value that is necessary in order to be able to setup which items to include in
+    // the questions asked when tracking each, but it is only included in copying and coding so that this 
+    // step does not need a reverse weak link to the data store.
+}
+
+public class SBATrackedActivityPageStepViewController: ORKPageStepViewController {
+    
+    override public var result: ORKStepResult? {
+        guard let stepResult = super.result else { return nil }
+        
+        // Get the choice answers
+        var formIdentifier = self.step!.identifier
+        let choiceAnswers = self.pageStep?.pageTask.steps.mapAndFilter({ (step) -> AnyObject? in
+            
+            guard let formStep = step as? ORKFormStep,
+                let formItem = formStep.formItems?.first,
+                let formResult = stepResult.resultForIdentifier("\(step.identifier).\(formItem.identifier)") as? ORKQuestionResultAnswerJSON,
+                let answer = formResult.jsonSerializedAnswer()
+                else {
+                    return nil
+            }
+            
+            // keep track of the identifier for the form item and use this for the identifier for the 
+            // consolidated result
+            formIdentifier = formItem.identifier
+            
+            // create and return a mapping of identifier to value
+            var value = answer.value
+            if let array = value as? NSArray where array.count == 1 {
+                value = array.firstObject!
+            }
+            return ["identifier" : step.identifier, "answer" : value] as NSDictionary
+        })
+        
+        // Create and return a result for the consolidated steps
+        let questionResult = ORKChoiceQuestionResult(identifier: formIdentifier)
+        questionResult.startDate = stepResult.startDate
+        questionResult.endDate = stepResult.endDate
+        questionResult.questionType = ORKQuestionType.MultipleChoice
+        questionResult.choiceAnswers = choiceAnswers ?? []
+        stepResult.addResult(questionResult)
+
+        return stepResult
+    }
+}

--- a/BridgeAppSDK/SBATrackedDataStore.m
+++ b/BridgeAppSDK/SBATrackedDataStore.m
@@ -283,13 +283,17 @@ static  NSTimeInterval  kMinimumAmountOfTimeToShowMedChangedSurvey         = 30.
 - (void)updateMomentInDayIdMap:(NSArray <ORKStep *> *)activitySteps {
     NSMutableArray *idMap = [NSMutableArray new];
     NSMutableDictionary *trackEachMap = [NSMutableDictionary new];
-    for (ORKFormStep *step in activitySteps) {
-        if ([step isKindOfClass:[ORKFormStep class]]) {
-            ORKFormItem *formItem = [step.formItems firstObject];
+    for (ORKStep *step in activitySteps) {
+        ORKStep *formStep = step;
+        // If this is a page step then set the formStep to the first step and map this as a trackEach
+        if ([step isKindOfClass:[SBATrackedActivityPageStep class]]) {
+            trackEachMap[step.identifier] = @YES;
+            formStep = [((SBATrackedActivityPageStep*)step).pageTask.steps firstObject];
+        }
+        // Look for a formItem identifier to map
+        if ([formStep isKindOfClass:[ORKFormStep class]]) {
+            ORKFormItem *formItem = [((ORKFormStep*)formStep).formItems firstObject];
             if (formItem != nil) {
-                if ([step isKindOfClass:[SBATrackedFormStep class]]) {
-                    trackEachMap[step.identifier] = @(((SBATrackedFormStep*)step).trackEach);
-                }
                 [idMap addObject:@[step.identifier, formItem.identifier]];
             }
         }

--- a/BridgeAppSDKTests/SBAEqualityTests.m
+++ b/BridgeAppSDKTests/SBAEqualityTests.m
@@ -128,7 +128,8 @@ MAKE_TEST_INIT(ORKQuestionResult, ^{return [self initWithIdentifier:[NSUUID UUID
              [SBASurveySubtaskStep class],
              [SBASurveyFormItem class],
              [SBATrackedFormStep class],
-             [SBATrackedDataSelectionResult class]
+             [SBATrackedDataSelectionResult class],
+             [SBATrackedActivityFormStep class]
              ];
 }
 

--- a/BridgeAppSDKTests/SBASubtaskStepTests.swift
+++ b/BridgeAppSDKTests/SBASubtaskStepTests.swift
@@ -102,7 +102,7 @@ class SBASubtaskStepTests: XCTestCase {
             XCTAssert(false, "\(step3) not of expected type")
             return
         }
-        taskResult.results! += [formStep3.instantiateStepResult(.first)]
+        taskResult.results! += [formStep3.instantiateDefaultStepResult()]
         
         let step4 = navTask.stepAfterStep(step3, withResult: taskResult)
         XCTAssertNotNil(step4)


### PR DESCRIPTION
This converts the activity timing steps to use a subclass of ORKFormStep if tracking grouped and a subclass of ORKPageStep if tracking each. While the ORKStep and ORKTask cannot mutate the ORKTaskResult, the ORKStepViewController can mutate the ORKStepResult for it's step. This implementation takes advantage of that to override the step result returned by the view controller to add the consolidated result that is returned to the server (and read into the synapse table). I am hoping to also refactor the selection/frequency steps to use an ORKPageStep subclass, but this one is a little less complicated so thought I would start with this part.

This requires pointing at Sage-Bionetworks/ResearchKit/sage-master until such time as https://github.com/ResearchKit/ResearchKit/pull/758 is accepted into ResearchKit/master and we have had a chance to fix any breaking changes in Apple's master branch. 
