### PR TITLE
Bridge-1487: ResearchKit: Navigation results are pointing to identical objects

### DIFF
--- a/BridgeAppSDK/SequenceType+Utilities.swift
+++ b/BridgeAppSDK/SequenceType+Utilities.swift
@@ -87,5 +87,18 @@ extension Sequence {
         }
         return nil
     }
+    
+    /**
+     Find the last element  with the given `identifier`
+    */
+    public func findLast(withIdentifier identifier: String) -> Self.Iterator.Element? {
+        for element in self.reversed() {
+            if let obj = element as? NSObject,
+                let id = obj.value(forKey: "identifier") as? String, (id == identifier) {
+                return element
+            }
+        }
+        return nil
+    }
 
 }

--- a/BridgeAppSDKTests/SBAScheduledActivityManagerTests.swift
+++ b/BridgeAppSDKTests/SBAScheduledActivityManagerTests.swift
@@ -540,17 +540,20 @@ class SBAScheduledActivityManagerTests: XCTestCase {
         checkValidation(splitResults)
         checkDuplicateFilenames(splitResults)
         
-        // TODO: syoung 08/29/2016 See comment in the consolidatedResult code.
-        //        let countdownResult = result.stepResultForStepIdentifier("countdown")
-        //        XCTAssertNotNil(countdownResult)
-        //        XCTAssertNotNil(countdownResult?.results)
-        //        guard let countdownResults = countdownResult?.results else { return }
-        //        XCTAssertEqual(countdownResults.count, 3)
-        //        
-        //        // Additional results should be kept. Only the most recent should *not* have _dup# appended to the identifier
-        //        let resultIdentifiers = countdownResults.map({ $0.identifier })
-        //        let expectedResultIdentifiers = [ "file", "file_dup0", "file_dup1"]
-        //        XCTAssertEqual(resultIdentifiers, expectedResultIdentifiers)
+        let countdownResult = result.stepResult(forStepIdentifier: "countdown")
+        XCTAssertNotNil(countdownResult)
+        XCTAssertNotNil(countdownResult?.results)
+        guard let countdownResults = countdownResult?.results else { return }
+        XCTAssertEqual(countdownResults.count, 3)
+        
+        // Additional results should be kept. Only the most recent should *not* have _dup# appended to the identifier
+        let resultIdentifiers = countdownResults.map({ $0.identifier })
+        let expectedResultIdentifiers = [ "file", "file_dup1", "file_dup2"]
+        XCTAssertEqual(resultIdentifiers, expectedResultIdentifiers)
+        
+        let lastCountdownResult = (taskVC.taskResult.results?.findLast(withIdentifier: "countdown") as? ORKStepResult)?.results?.first
+        XCTAssertNotNil(lastCountdownResult)
+        XCTAssertEqual(lastCountdownResult?.identifier, "file")
     }
     
     func checkValidation(_ splitResults: [SBAActivityResult]) {


### PR DESCRIPTION
Fixed RK: https://github.com/ResearchKit/ResearchKit/pull/828

This removes our work-around to the duplicate `ORKResult` objects in the results array returned by the task. This has been fixed with a PR to ResearchKit and merged to our sage branch.
