### PR TITLE
Bridge 1226 Refactor Permissions to support HealthKit

### DIFF
--- a/BridgeAppSDK.xcodeproj/project.pbxproj
+++ b/BridgeAppSDK.xcodeproj/project.pbxproj
@@ -187,6 +187,7 @@
 		FF92A6831DBFF21700614D1F /* LearnInfo.plist in Resources */ = {isa = PBXBuildFile; fileRef = FF92A6821DBFF21700614D1F /* LearnInfo.plist */; };
 		FF92A6C71DC026AC00614D1F /* Withdraw.json in Resources */ = {isa = PBXBuildFile; fileRef = FF92A6C91DC026AC00614D1F /* Withdraw.json */; };
 		FF92A6DA1DC15FE700614D1F /* NewsfeedTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF92A6D91DC15FE700614D1F /* NewsfeedTableViewController.swift */; };
+		FF9312391DC93327001A9F86 /* SBAPermissionObjectType.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF9312381DC93327001A9F86 /* SBAPermissionObjectType.swift */; };
 		FF9634C71C9A0A6600D07595 /* SBASurveyItem+Bridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF9634C61C9A0A6600D07595 /* SBASurveyItem+Bridge.swift */; };
 		FF9707F61DA6D5DB006E8252 /* SBAConsentSharingStep.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF9707F51DA6D5DB006E8252 /* SBAConsentSharingStep.swift */; };
 		FF9708041DA7104F006E8252 /* SBAConsentSubtaskStep.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF9708031DA7104F006E8252 /* SBAConsentSubtaskStep.swift */; };
@@ -598,6 +599,7 @@
 		FF92A6821DBFF21700614D1F /* LearnInfo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = LearnInfo.plist; sourceTree = "<group>"; };
 		FF92A6C81DC026AC00614D1F /* Base */ = {isa = PBXFileReference; lastKnownFileType = text.json; name = Base; path = Base.lproj/Withdraw.json; sourceTree = "<group>"; };
 		FF92A6D91DC15FE700614D1F /* NewsfeedTableViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NewsfeedTableViewController.swift; sourceTree = "<group>"; };
+		FF9312381DC93327001A9F86 /* SBAPermissionObjectType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SBAPermissionObjectType.swift; sourceTree = "<group>"; };
 		FF9634C61C9A0A6600D07595 /* SBASurveyItem+Bridge.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "SBASurveyItem+Bridge.swift"; sourceTree = "<group>"; };
 		FF9707F51DA6D5DB006E8252 /* SBAConsentSharingStep.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SBAConsentSharingStep.swift; sourceTree = "<group>"; };
 		FF9708031DA7104F006E8252 /* SBAConsentSubtaskStep.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SBAConsentSubtaskStep.swift; sourceTree = "<group>"; };
@@ -1260,6 +1262,7 @@
 				FFAAF61D1CC0267E00500929 /* SBAPermissionsManager.m */,
 				FFF05FAA1D5A4FCC007304FF /* SBAPermissionsManager.swift */,
 				FFB30EB01D4A8AB000D175D2 /* SBAPermissionsStep.swift */,
+				FF9312381DC93327001A9F86 /* SBAPermissionObjectType.swift */,
 			);
 			name = Permissions;
 			sourceTree = "<group>";
@@ -1863,6 +1866,7 @@
 				FF23799F1CBC2E5900F3A943 /* NSDictionary+Utilities.swift in Sources */,
 				FB8439191C727BEB0086E961 /* SBASurveyFactory.swift in Sources */,
 				FFDCB56D1D9AF161004A0CC5 /* ORKStep+ResultsExtension.swift in Sources */,
+				FF9312391DC93327001A9F86 /* SBAPermissionObjectType.swift in Sources */,
 				FF92A6441DBFE16C00614D1F /* SBALearnInfo.swift in Sources */,
 				FF9E48961CF3A2F1005EE7E0 /* StaticUtilities.swift in Sources */,
 				FF5051D51D6653670065E677 /* SBAOnboardingCompleteStep.swift in Sources */,

--- a/BridgeAppSDK/Base.lproj/BridgeAppSDK.strings
+++ b/BridgeAppSDK/Base.lproj/BridgeAppSDK.strings
@@ -130,7 +130,10 @@
 "SBA_CAMERA_PERMISSIONS_TITLE" = "Camera";
 "SBA_PHOTOLIBRARY_PERMISSIONS_TITLE" = "Photo Library";
 "SBA_HEALTHKIT_PERMISSIONS_DESCRIPTION" = "Press “Allow” to individually specify which general health information the app may read from and write to HealthKit";
-"SBA_REMINDER_PERMISSIONS_DESCRIPTION" = "Allowing notifications enables the app to show you reminders for activity sessions.";
+"SBA_NOTIFICATIONS_PERMISSIONS_DESCRIPTION" = "Allowing notifications enables the app to show you reminders for activity sessions.";
+"SBA_LOCATION_PERMISSIONS_DESCRIPTION" = "Using your GPS enables the app to accurately determine distances travelled. Your actual location will never be shared.";
+"SBA_COREMOTION_PERMISSIONS_DESCRIPTION" = "Using the motion co-processor allows the app to determine your activity, helping the study better understand how activity level may influence disease.";
+"SBA_MICROPHONE_PERMISSIONS_DESCRIPTION" = "Access to microphone is required for your Voice Recording Activity.";
 "SBA_HEALTHKIT_PERMISSIONS_ERROR" = "Please go to Settings -> Privacy -> Health -> %@ to re-enable.";
 "SBA_REMINDER_PERMISSIONS_ERROR" = "Tap on Settings -> Notifications and enable 'Allow Notifications'";
 "SBA_LOCATION_PERMISSIONS_ERROR" = "Tap on Settings -> Location and check 'Always'";

--- a/BridgeAppSDK/Localization.swift
+++ b/BridgeAppSDK/Localization.swift
@@ -92,7 +92,17 @@ open class Localization: NSObject {
         }
     }
     
-    
+    public static func localizedBundleString(_ bundleKey: String, localizedKey: String) -> String {
+        guard let info = Bundle.main.localizedInfoDictionary ?? Bundle.main.infoDictionary,
+              let str = info[bundleKey] as? String
+        else {
+            // The calling app is expected to include these keys so assert if missing
+            assertionFailure("Missing required main bundle info.plist key \(bundleKey)")
+            return self.localizedString(localizedKey)
+        }
+        return str
+    }
+            
     // MARK: Localized App Name
     
     open static let localizedAppName : String = {

--- a/BridgeAppSDK/SBAAppDelegate.swift
+++ b/BridgeAppSDK/SBAAppDelegate.swift
@@ -54,6 +54,8 @@ public protocol SBAAppInfoDelegate: NSObjectProtocol {
 public protocol SBABridgeAppSDKDelegate : UIApplicationDelegate, SBAAppInfoDelegate, SBBBridgeAppDelegate, SBAAlertPresenter {
     
     // Start-up permissions
+    @available(*, deprecated, message:"Use `permissionTypeItems` on `SBABridgeInfo` instead.")
+    @objc optional
     var requiredPermissions: SBAPermissionsType { get }
     
     // Resource handling
@@ -147,7 +149,7 @@ let SBAMainStoryboardName = "Main"
     }
     
     open func application(_ application: UIApplication, didRegister notificationSettings: UIUserNotificationSettings) {
-        SBAPermissionsManager.shared.appDidRegister(forRemoteNotifications: notificationSettings)
+        SBAPermissionsManager.shared.appDidRegister(forNotifications: notificationSettings)
     }
     
     open func application(_ application: UIApplication, handleEventsForBackgroundURLSession identifier: String, completionHandler: @escaping () -> Void) {
@@ -178,13 +180,6 @@ let SBAMainStoryboardName = "Main"
         return _currentUser
     }
     private let _currentUser = SBAUser()
-    
-    /**
-     Override to set the permissions for this application.
-    */
-    open var requiredPermissions: SBAPermissionsType {
-        return SBAPermissionsType()
-    }
     
     private func initializeBridgeServerConnection() {
         

--- a/BridgeAppSDK/SBABridgeInfo.swift
+++ b/BridgeAppSDK/SBABridgeInfo.swift
@@ -115,6 +115,11 @@ public protocol SBABridgeInfo: class {
      do not check for a text user.
     */
     var disableTestUserCheck: Bool { get }
+    
+    /**
+     Array of objects that can be converted into `SBAPermissionObjectType` objects.
+    */
+    var permissionTypeItems: [Any]? { get }
 }
 
 /**
@@ -207,6 +212,10 @@ public final class SBABridgeInfoPList : NSObject, SBABridgeInfo {
     
     public var disableTestUserCheck: Bool {
         return self.plist["disableTestUserCheck"] as? Bool ?? false
+    }
+    
+    public var permissionTypeItems: [Any]? {
+        return self.plist["permissionTypes"] as? [Any]
     }
 }
 

--- a/BridgeAppSDK/SBADataObject.h
+++ b/BridgeAppSDK/SBADataObject.h
@@ -76,7 +76,7 @@ NS_ASSUME_NONNULL_BEGIN
  
  @return A new data object.
  */
-- (instancetype)initWithCoder:(NSCoder *)aDecoder;
+- (instancetype)initWithCoder:(NSCoder *)aDecoder NS_DESIGNATED_INITIALIZER;
 
 /**
  * Mapping name for the type of object class. By Default, this is the coderForClass.

--- a/BridgeAppSDK/SBADataObject.m
+++ b/BridgeAppSDK/SBADataObject.m
@@ -108,7 +108,7 @@
 - (id)objectWithDictionaryRepresentation:(NSDictionary*)dictionary classType:(NSString*)aClassType {
     
     // SBBObjects use type for the class type so check both the property key for this class and the SBBObject property key
-    NSString *classType = aClassType ?: dictionary[[[self class] classTypeKey]] ?: dictionary[@"classType"];
+    NSString *classType = aClassType ?: dictionary[[[self class] classTypeKey]] ?: dictionary[@"type"];
     if (classType == nil) {
         return dictionary;
     }

--- a/BridgeAppSDK/SBADataObject.m
+++ b/BridgeAppSDK/SBADataObject.m
@@ -58,17 +58,22 @@
 
 - (instancetype)initWithDictionaryRepresentation:(NSDictionary *)dictionary {
     if ((self = [super init])) {
-        for (NSString *key in [self dictionaryRepresentationKeys]) {
-            id value = dictionary[key];
-            if (value && ![value isKindOfClass:[NSNull class]]) {
-                [self setValue:value forKey:key];
-            }
-        }
-        if (_identifier == nil) {
-            _identifier = [self defaultIdentifierIfNil];
-        }
+        [self commonInitWithDictionaryRepresentation:dictionary];
     }
     return self;
+}
+
+- (void)commonInitWithDictionaryRepresentation:(NSDictionary *)dictionary {
+    for (NSString *key in [self dictionaryRepresentationKeys]) {
+        id value = dictionary[key];
+        if (value && ![value isKindOfClass:[NSNull class]]) {
+            [self setValue:value forKey:key];
+        }
+    }
+    if (_identifier == nil) {
+        _identifier = [self defaultIdentifierIfNil];
+    }
+
 }
 
 - (void)setValue:(id)value forKey:(NSString *)key {
@@ -103,7 +108,7 @@
 - (id)objectWithDictionaryRepresentation:(NSDictionary*)dictionary classType:(NSString*)aClassType {
     
     // SBBObjects use type for the class type so check both the property key for this class and the SBBObject property key
-    NSString *classType = aClassType ?: dictionary[[[self class] classTypeKey]] ?: dictionary[@"type"];
+    NSString *classType = aClassType ?: dictionary[[[self class] classTypeKey]] ?: dictionary[@"classType"];
     if (classType == nil) {
         return dictionary;
     }
@@ -168,8 +173,11 @@
 }
 
 - (instancetype)initWithCoder:(NSCoder *)aDecoder {
-    NSDictionary *dictionary = [aDecoder decodeObjectOfClass:[NSDictionary class] forKey:@"dictionary"];
-    return [self initWithDictionaryRepresentation:dictionary];
+    if ((self = [super init])) {
+        NSDictionary *dictionary = [aDecoder decodeObjectOfClass:[NSDictionary class] forKey:@"dictionary"];
+        [self commonInitWithDictionaryRepresentation:dictionary];
+    }
+    return self;
 }
 
 - (void)encodeWithCoder:(NSCoder *)aCoder {

--- a/BridgeAppSDK/SBALoadingView.swift
+++ b/BridgeAppSDK/SBALoadingView.swift
@@ -50,7 +50,7 @@ open class SBALoadingView: UIView {
     
     lazy var containerView: UIView = {
         let containerView = UIView()
-        containerView.backgroundColor = UIColor(white: 0, alpha: 0.2)
+        containerView.backgroundColor = UIColor(white: 0, alpha: 0.5)
         containerView.bounds = CGRect(x: 0, y: 0, width: 100, height: 100)
         containerView.layer.cornerRadius = 5
         self.addSubview(containerView)

--- a/BridgeAppSDK/SBANotificationsManager.swift
+++ b/BridgeAppSDK/SBANotificationsManager.swift
@@ -59,7 +59,7 @@ open class SBANotificationsManager: NSObject, SBASharedInfoController {
     
     @objc(setupNotificationsForScheduledActivities:)
     open func setupNotifications(for scheduledActivities: [SBBScheduledActivity]) {
-        permissionsManager.requestPermissions(.localNotifications, alertPresenter: nil) { [weak self] (granted) in
+        permissionsManager.requestPermission(for: SBANotificationPermissionObjectType.localNotifications()) { [weak self] (granted, _) in
             if granted {
                 self?.scheduleNotifications(scheduledActivities: scheduledActivities)
             }

--- a/BridgeAppSDK/SBAPermissionObjectType.swift
+++ b/BridgeAppSDK/SBAPermissionObjectType.swift
@@ -404,8 +404,8 @@ extension SBAPermissionTypeIdentifier {
     public func defaultDescription() -> String {
         switch (self) {
         case SBAPermissionTypeIdentifier.healthKit:
-            return Localization.localizedBundleString("NSHealthShareUsageDescription",
-                                                      localizedKey: "SBA_HEALTHKIT_PERMISSIONS_DESCRIPTION")
+            return Localization..localizedString("SBA_HEALTHKIT_PERMISSIONS_DESCRIPTION")
+            
         case SBAPermissionTypeIdentifier.location:
             return Localization.localizedBundleString("NSLocationWhenInUseUsageDescription",
                                                       localizedKey: "SBA_LOCATION_PERMISSIONS_DESCRIPTION")

--- a/BridgeAppSDK/SBAPermissionObjectType.swift
+++ b/BridgeAppSDK/SBAPermissionObjectType.swift
@@ -1,0 +1,430 @@
+//
+//  SBAPermissionType.swift
+//  BridgeAppSDK
+//
+//  Copyright © 2016 Sage Bionetworks. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification,
+// are permitted provided that the following conditions are met:
+//
+// 1.  Redistributions of source code must retain the above copyright notice, this
+// list of conditions and the following disclaimer.
+//
+// 2.  Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation and/or
+// other materials provided with the distribution.
+//
+// 3.  Neither the name of the copyright holder(s) nor the names of any contributors
+// may be used to endorse or promote products derived from this software without
+// specific prior written permission. No license is granted to the trademarks of
+// the copyright holders even if such marks are included in this software.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+
+import Foundation
+import HealthKit
+
+/**
+ Factory for creating `SBAPermissionObjectType` instances.
+ 
+ `String` keys are defined with a mapping for:
+    "healthKit"
+    "location"
+    "notifications"
+    "coremotion"
+    "microphone"
+    "camera"
+    "photoLibrary"
+ 
+ A dictionary of type `[String : Any]` can map to object types where:
+ 
+    SBAPermissionObjectType
+    "identifier" = `String` value from the list defined above
+ 
+    SBANotificationPermissionObjectType
+    "notificationTypes" = ["alert", "badge", "sound"]   // Default = ["alert", "badge", "sound"]
+ 
+    SBALocationPermissionObjectType
+    "always" = true/false  // Default = `NO`
+ 
+    SBAHealthKitPermissionObjectType
+    "healthKitTypes" = [SBAHealthKitProfileObject<String or [String : Any]>]
+ 
+        SBAHealthKitProfileObject
+        "identifier" = valid HKObjectTypeIdentifier
+        "profileKey" = mapping to a key in the user profile (optional)
+        "readonly" = true/false // Default = `NO`
+ 
+ */
+open class SBAPermissionObjectTypeFactory: NSObject {
+    
+    @objc
+    open func permissionTypes(for items:[Any]?) -> [SBAPermissionObjectType] {
+        guard let inputItems = items else { return [] }
+        return inputItems.map({ self.permissionType(for: $0) })
+    }
+    
+    @objc
+    open func permissionType(for item:Any) -> SBAPermissionObjectType {
+        if let identifier = item as? String {
+            // If the item is a string then create a permission object for the given identifier
+            return self.permissionType(with: SBAPermissionTypeIdentifier(rawValue: identifier))
+        }
+        else if let permissionTypeIdentifier = item as? SBAPermissionTypeIdentifier {
+            // If this is a permission type identifier enum then return type for that
+            return self.permissionType(with: permissionTypeIdentifier)
+        }
+        else if let dictionary = item as? [String : Any] {
+            // If this is a dictionary, first look to see if the class type map includes a non-nil
+            // object for this dictionary
+            if let permissionType = SBAClassTypeMap.shared.object(with: dictionary) as? SBAPermissionObjectType {
+                return permissionType
+            }
+            // Otherwise, look for an identifier and use that to get the permission type
+            // Then set the values from the dictionary using KVO
+            else if let identifier = dictionary["identifier"] as? String {
+                let permissionType = self.permissionType(with: SBAPermissionTypeIdentifier(rawValue: identifier))
+                permissionType.setValuesForKeys(dictionary)
+                return permissionType
+            }
+        }
+        
+        // Define a default but assert on unrecognized type
+        assertionFailure("Unrecognized item type: \(item)")
+        return SBAPermissionObjectType(identifier: "unknown")
+    }
+    
+    fileprivate func permissionType(with permissionTypeIdentifier:SBAPermissionTypeIdentifier) -> SBAPermissionObjectType {
+        switch (permissionTypeIdentifier) {
+        case SBAPermissionTypeIdentifier.notifications:
+            return SBANotificationPermissionObjectType(permissionType: permissionTypeIdentifier)
+        case SBAPermissionTypeIdentifier.location:
+            return SBALocationPermissionObjectType(permissionType: permissionTypeIdentifier)
+        case SBAPermissionTypeIdentifier.healthKit:
+            return SBAHealthKitPermissionObjectType(permissionType: permissionTypeIdentifier)
+        default:
+            return SBAPermissionObjectType(permissionType: permissionTypeIdentifier)
+        }
+    }
+}
+
+open class SBAPermissionObjectType: SBADataObject {
+    
+    open var permissionType: SBAPermissionTypeIdentifier {
+        return SBAPermissionTypeIdentifier(rawValue: self.identifier)
+    }
+    
+    open dynamic var title: String?
+    open dynamic var detail: String?
+    
+    override open func dictionaryRepresentationKeys() -> [String] {
+        var keys = super.dictionaryRepresentationKeys()
+        keys.append(#keyPath(title))
+        keys.append(#keyPath(detail))
+        return keys
+    }
+    
+    public override init(identifier: String) {
+        super.init(identifier: identifier)
+        commonInit()
+    }
+    
+    public required init(coder aDecoder: NSCoder) {
+        super.init(coder: aDecoder)
+        commonInit()
+    }
+    
+    public required init(dictionaryRepresentation dictionary: [AnyHashable : Any]) {
+        super.init(dictionaryRepresentation: dictionary)
+        commonInit()
+    }
+    
+    public init(permissionType: SBAPermissionTypeIdentifier) {
+        super.init(identifier: permissionType.rawValue)
+        commonInit()
+    }
+    
+    fileprivate func commonInit() {
+        if self.title == nil {
+            self.title = self.permissionType.defaultTitle()
+        }
+        if self.detail == nil {
+            self.detail = self.permissionType.defaultDescription()
+        }
+    }
+}
+
+extension UIUserNotificationType {
+    init(keys: [String]) {
+        let rawValue = keys.map({ (name) -> UInt in
+            switch (name) {
+            case "alert":
+                return UIUserNotificationType.alert.rawValue
+            case "badge":
+                return UIUserNotificationType.badge.rawValue
+            case "sound":
+                return UIUserNotificationType.sound.rawValue
+            default:
+                return 0
+            }
+        }).reduce(0, |)
+        self.init(rawValue: rawValue)
+    }
+}
+
+public final class SBANotificationPermissionObjectType: SBAPermissionObjectType {
+    
+    class func localNotifications() -> SBANotificationPermissionObjectType {
+        return SBANotificationPermissionObjectType(permissionType: .notifications)
+    }
+    
+    override open func defaultIdentifierIfNil() -> String {
+        return SBAPermissionTypeIdentifier.notifications.rawValue
+    }
+    
+    public var categories: Set<UIUserNotificationCategory>?
+    
+    public dynamic var notificationTypes: UIUserNotificationType = [.alert, .badge, .sound]
+    
+    override public func dictionaryRepresentation() -> [AnyHashable : Any] {
+        var dictionary = super.dictionaryRepresentation()
+        let keyPath = #keyPath(notificationTypes)
+        dictionary[keyPath] = notificationTypes.rawValue
+        return dictionary
+    }
+    
+    override public func setValue(_ value: Any?, forKey key: String) {
+        switch (key) {
+        case #keyPath(notificationTypes):
+            customSetNotificationTypes(value)
+        default:
+            super.setValue(value, forKey: key)
+        }
+    }
+    
+    fileprivate func customSetNotificationTypes(_ value: Any?) {
+        if let types = value as? UIUserNotificationType {
+            self.notificationTypes = types
+        }
+        else if let types = value as? UInt {
+            self.notificationTypes = UIUserNotificationType(rawValue: types)
+        }
+        else if let types = value as? [String] {
+            self.notificationTypes = UIUserNotificationType(keys: types)
+        }
+        else {
+            assertionFailure("Failed to convert \(value) to UIUserNotificationType")
+        }
+    }
+}
+
+public final class SBALocationPermissionObjectType: SBAPermissionObjectType {
+    
+    public dynamic var always: Bool = true
+    
+    override open func defaultIdentifierIfNil() -> String {
+        return SBAPermissionTypeIdentifier.location.rawValue
+    }
+    
+    override public func dictionaryRepresentationKeys() -> [String] {
+        var keys = super.dictionaryRepresentationKeys()
+        keys.append(#keyPath(always))
+        return keys
+    }
+}
+
+public final class SBAHealthKitPermissionObjectType: SBAPermissionObjectType {
+    
+    public dynamic var healthKitTypes: [SBAHealthKitProfileObject]?
+    
+    public var writeTypes: Set<HKSampleType>? {
+        guard let profileObjects = healthKitTypes else { return nil }
+        return Set(profileObjects.mapAndFilter({ (profileObject) -> HKSampleType? in
+            guard !profileObject.readonly else { return nil }
+            return profileObject._hkObjectType as? HKSampleType
+        }))
+    }
+    
+    public var readTypes: Set<HKObjectType>? {
+        guard let profileObjects = healthKitTypes else { return nil }
+        return Set(profileObjects.mapAndFilter({ (profileObject) -> HKObjectType? in
+            return profileObject._hkObjectType
+        }))
+    }
+
+    override open func defaultIdentifierIfNil() -> String {
+        return SBAPermissionTypeIdentifier.healthKit.rawValue
+    }
+    
+    override public func dictionaryRepresentationKeys() -> [String] {
+        var keys = super.dictionaryRepresentationKeys()
+        keys.append(#keyPath(healthKitTypes))
+        return keys
+    }
+    
+    override public func setValue(_ value: Any?, forKey key: String) {
+        switch (key) {
+            
+        case #keyPath(healthKitTypes):
+            let items = value as? [Any]
+            healthKitTypes = items?.mapAndFilter({ (item) -> SBAHealthKitProfileObject? in
+                if let profileObject = item as? SBAHealthKitProfileObject {
+                    return profileObject
+                }
+                
+                // Look for the item to be either a string or dictionary
+                let profileObject: SBAHealthKitProfileObject? = {
+                    if let typeIdentifier = item as? String {
+                        return SBAHealthKitProfileObject(identifier: typeIdentifier)
+                    }
+                    else if let dictionary = item as? [String : Any] {
+                        return SBAHealthKitProfileObject(dictionaryRepresentation: dictionary)
+                    }
+                    return nil
+                }()
+                
+                // Nil out if the health type is not nl
+                guard profileObject?._hkObjectType != nil else {
+                    return nil
+                }
+                
+                return profileObject
+            })
+
+        default:
+            super.setValue(value, forKey: key)
+        }
+    }
+}
+
+public final class SBAHealthKitProfileObject: SBADataObject {
+    
+    public dynamic var profileKey: String?
+    public dynamic var readonly: Bool = false
+    
+    override public func dictionaryRepresentationKeys() -> [String] {
+        var keys = super.dictionaryRepresentationKeys()
+        keys.append(#keyPath(profileKey))
+        keys.append(#keyPath(readonly))
+        return keys
+    }
+    
+    public var hkObjectType: HKObjectType! {
+        return _hkObjectType
+    }
+    lazy fileprivate var _hkObjectType: HKObjectType? = {
+        
+        // Check if this is a quantity type
+        let quantityTypeIdentifier = HKQuantityTypeIdentifier(rawValue: self.identifier)
+        if let type = HKObjectType.quantityType(forIdentifier: quantityTypeIdentifier) {
+            return type
+        }
+        
+        // Check if this is a category type
+        let categoryTypeIdentifier = HKCategoryTypeIdentifier(rawValue: self.identifier)
+        if let type = HKObjectType.categoryType(forIdentifier: categoryTypeIdentifier) {
+            return type
+        }
+        
+        // Check if this is a category type
+        let characteristicTypeIdentifier = HKCharacteristicTypeIdentifier(rawValue: self.identifier)
+        if let type = HKObjectType.characteristicType(forIdentifier: characteristicTypeIdentifier) {
+            return type
+        }
+        
+        // Check if this is a category type
+        let correlationTypeIdentifier = HKCorrelationTypeIdentifier(rawValue: self.identifier)
+        if let type = HKObjectType.correlationType(forIdentifier: correlationTypeIdentifier) {
+            return type
+        }
+        
+        // open class func workoutType() -> HKWorkoutType
+        let workoutTypeIdentifier = String(describing: HKWorkoutType.classForCoder())
+        if self.identifier == workoutTypeIdentifier {
+            return HKObjectType.workoutType()
+        }
+        
+        guard #available(iOS 9.3, *) else { return nil }
+        let activitySummaryTypeIdentifier = String(describing: HKActivitySummaryType.classForCoder())
+        if self.identifier == activitySummaryTypeIdentifier {
+            return HKObjectType.activitySummaryType()
+        }
+        
+        guard #available(iOS 10, *) else { return nil }
+        let documentTypeIdentifier = HKDocumentTypeIdentifier(rawValue: self.identifier)
+        if let type = HKObjectType.documentType(forIdentifier: documentTypeIdentifier) {
+            return type
+        }
+        
+        return nil
+    }()
+}
+
+extension SBAPermissionTypeIdentifier {
+    
+    /**
+     Returns the default title to use for a given permission.
+     @return   Default title
+     */
+    public func defaultTitle() -> String {
+        switch (self) {
+        case SBAPermissionTypeIdentifier.healthKit:
+            return Localization.localizedString("SBA_HEALTHKIT_PERMISSIONS_TITLE")
+        case SBAPermissionTypeIdentifier.location:
+            return Localization.localizedString("SBA_LOCATION_PERMISSIONS_TITLE")
+        case SBAPermissionTypeIdentifier.coremotion:
+            return Localization.localizedString("SBA_COREMOTION_PERMISSIONS_TITLE")
+        case SBAPermissionTypeIdentifier.notifications:
+            return Localization.localizedString("SBA_REMINDER_PERMISSIONS_TITLE")
+        case SBAPermissionTypeIdentifier.microphone:
+            return Localization.localizedString("SBA_MICROPHONE_PERMISSIONS_TITLE")
+        case SBAPermissionTypeIdentifier.camera:
+            return Localization.localizedString("SBA_CAMERA_PERMISSIONS_TITLE")
+        case SBAPermissionTypeIdentifier.photoLibrary:
+            return Localization.localizedString("SBA_PHOTOLIBRARY_PERMISSIONS_TITLE")
+        default:
+            return ""
+        }
+    }
+    
+    /**
+     Returns the default description for the given permission
+     @return   Default description
+     */
+    public func defaultDescription() -> String {
+        switch (self) {
+        case SBAPermissionTypeIdentifier.healthKit:
+            return Localization.localizedBundleString("NSHealthShareUsageDescription",
+                                                      localizedKey: "SBA_HEALTHKIT_PERMISSIONS_DESCRIPTION")
+        case SBAPermissionTypeIdentifier.location:
+            return Localization.localizedBundleString("NSLocationWhenInUseUsageDescription",
+                                                      localizedKey: "SBA_LOCATION_PERMISSIONS_DESCRIPTION")
+        case SBAPermissionTypeIdentifier.coremotion:
+            return Localization.localizedBundleString("NSMotionUsageDescription",
+                                                      localizedKey: "SBA_COREMOTION_PERMISSIONS_DESCRIPTION")
+        case SBAPermissionTypeIdentifier.notifications:
+            return Localization.localizedString("SBA_NOTIFICATIONS_PERMISSIONS_DESCRIPTION")
+        case SBAPermissionTypeIdentifier.microphone:
+            return Localization.localizedBundleString("NSMicrophoneUsageDescription",
+                                                      localizedKey: "SBA_MICROPHONE_PERMISSIONS_DESCRIPTION")
+        case SBAPermissionTypeIdentifier.camera:
+            return Localization.localizedBundleString("NSCameraUsageDescription",
+                                                      localizedKey: "SBA_CAMERA_PERMISSIONS_TITLE")
+        case SBAPermissionTypeIdentifier.photoLibrary:
+            return Localization.localizedBundleString("NSPhotoLibraryUsageDescription",
+                                                      localizedKey: "SBA_PHOTOLIBRARY_PERMISSIONS_TITLE")
+        default:
+            return ""
+        }
+    }
+}

--- a/BridgeAppSDK/SBAPermissionObjectType.swift
+++ b/BridgeAppSDK/SBAPermissionObjectType.swift
@@ -1,5 +1,5 @@
 //
-//  SBAPermissionType.swift
+//  SBAPermissionObjectType.swift
 //  BridgeAppSDK
 //
 //  Copyright © 2016 Sage Bionetworks. All rights reserved.
@@ -52,18 +52,18 @@ import HealthKit
     "identifier" = `String` value from the list defined above
  
     SBANotificationPermissionObjectType
-    "notificationTypes" = ["alert", "badge", "sound"]   // Default = ["alert", "badge", "sound"]
+    "notificationTypes" = ["alert", "badge", "sound"], Default = ["alert", "badge", "sound"]
  
     SBALocationPermissionObjectType
-    "always" = true/false  // Default = `NO`
+    "always" = true/false, Default = false
  
     SBAHealthKitPermissionObjectType
     "healthKitTypes" = [SBAHealthKitProfileObject<String or [String : Any]>]
  
         SBAHealthKitProfileObject
         "identifier" = valid HKObjectTypeIdentifier
-        "profileKey" = mapping to a key in the user profile (optional)
-        "readonly" = true/false // Default = `NO`
+        "profileKey" = mapping to a key in the user profile (optional), Default = nil
+        "readonly" = true/false, Default = false
  
  */
 open class SBAPermissionObjectTypeFactory: NSObject {
@@ -336,13 +336,13 @@ public final class SBAHealthKitProfileObject: SBADataObject {
             return type
         }
         
-        // Check if this is a category type
+        // Check if this is a characteristic type
         let characteristicTypeIdentifier = HKCharacteristicTypeIdentifier(rawValue: self.identifier)
         if let type = HKObjectType.characteristicType(forIdentifier: characteristicTypeIdentifier) {
             return type
         }
         
-        // Check if this is a category type
+        // Check if this is a correlation type
         let correlationTypeIdentifier = HKCorrelationTypeIdentifier(rawValue: self.identifier)
         if let type = HKObjectType.correlationType(forIdentifier: correlationTypeIdentifier) {
             return type
@@ -404,7 +404,7 @@ extension SBAPermissionTypeIdentifier {
     public func defaultDescription() -> String {
         switch (self) {
         case SBAPermissionTypeIdentifier.healthKit:
-            return Localization..localizedString("SBA_HEALTHKIT_PERMISSIONS_DESCRIPTION")
+            return Localization.localizedString("SBA_HEALTHKIT_PERMISSIONS_DESCRIPTION")
             
         case SBAPermissionTypeIdentifier.location:
             return Localization.localizedBundleString("NSLocationWhenInUseUsageDescription",

--- a/BridgeAppSDK/SBAPermissionsManager.swift
+++ b/BridgeAppSDK/SBAPermissionsManager.swift
@@ -52,16 +52,16 @@ extension SBAPermissionsManager {
             // Use an enumerator to recursively step thorough each permission and request permission
             // for that type.
             var allGranted = true
-            let eumerator = (permissions as NSArray).objectEnumerator()
+            let enumerator = (permissions as NSArray).objectEnumerator()
             
-            func recursiveRequest() {
-                guard let permission = eumerator.nextObject() as? SBAPermissionObjectType else {
+            func enumerateRequest() {
+                guard let permission = enumerator.nextObject() as? SBAPermissionObjectType else {
                     completion?(allGranted)
                     return
                 }
 
                 if self.isPermissionGranted(for: permission) {
-                    recursiveRequest()
+                    enumerateRequest()
                 }
                 else {
                     self.requestPermission(for: permission, completion: { [weak alertPresenter] (success, error) in
@@ -72,19 +72,19 @@ extension SBAPermissionsManager {
                                     let title = Localization.localizedString("SBA_PERMISSIONS_FAILED_TITLE")
                                     let message = error?.localizedDescription ?? Localization.localizedString("SBA_PERMISSIONS_FAILED_MESSAGE")
                                     presenter.showAlertWithOk(title: title, message: message, actionHandler: { (_) in
-                                        recursiveRequest()
+                                        enumerateRequest()
                                     })
                                 
                             }
                             else {
-                                recursiveRequest()
+                                enumerateRequest()
                             }
                         })
                     })
                 }
             }
             
-            recursiveRequest()
+            enumerateRequest()
         })
     }
     

--- a/BridgeAppSDKSample/AppDelegate.swift
+++ b/BridgeAppSDKSample/AppDelegate.swift
@@ -37,10 +37,6 @@ import BridgeAppSDK
 @UIApplicationMain
 class AppDelegate: SBAAppDelegate {
     
-    override var requiredPermissions: SBAPermissionsType {
-        return [.coremotion, .localNotifications, .microphone]
-    }
-    
     override func applicationDidBecomeActive(_ application: UIApplication) {
         super.applicationDidBecomeActive(application)
         

--- a/BridgeAppSDKSample/Base.lproj/Main.storyboard
+++ b/BridgeAppSDKSample/Base.lproj/Main.storyboard
@@ -107,24 +107,16 @@
                                                 <action selector="leaveStudyTapped:" destination="WzD-eA-mg9" eventType="touchUpInside" id="x95-X6-NRP"/>
                                             </connections>
                                         </button>
-                                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="s7S-kb-ffn">
-                                            <state key="normal" title="Pause Study"/>
-                                            <connections>
-                                                <action selector="pauseStudyTapped:" destination="WzD-eA-mg9" eventType="touchUpInside" id="hNx-N1-hGn"/>
-                                            </connections>
-                                        </button>
                                     </subviews>
                                     <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                     <constraints>
-                                        <constraint firstAttribute="trailing" secondItem="s7S-kb-ffn" secondAttribute="trailing" id="2qt-tY-yJF"/>
                                         <constraint firstItem="pQa-uc-wPG" firstAttribute="top" secondItem="5gW-Uf-QEf" secondAttribute="bottom" constant="7" id="4hk-8Y-ogv"/>
                                         <constraint firstAttribute="trailing" secondItem="z1W-30-kzX" secondAttribute="trailing" id="4xN-1U-3oO"/>
                                         <constraint firstItem="5gW-Uf-QEf" firstAttribute="leading" secondItem="1qM-8O-PFO" secondAttribute="leading" id="8bp-Zg-Eiz"/>
+                                        <constraint firstItem="pQa-uc-wPG" firstAttribute="baseline" secondItem="z1W-30-kzX" secondAttribute="baseline" id="Xd7-g3-kr0"/>
                                         <constraint firstAttribute="bottom" secondItem="pQa-uc-wPG" secondAttribute="bottom" id="Yal-uh-1W7"/>
                                         <constraint firstItem="5gW-Uf-QEf" firstAttribute="top" secondItem="1qM-8O-PFO" secondAttribute="top" id="cOP-Mf-z1T"/>
                                         <constraint firstItem="pQa-uc-wPG" firstAttribute="leading" secondItem="1qM-8O-PFO" secondAttribute="leading" id="chL-K4-XJi"/>
-                                        <constraint firstItem="z1W-30-kzX" firstAttribute="baseline" secondItem="5gW-Uf-QEf" secondAttribute="baseline" id="lP6-gI-GOm"/>
-                                        <constraint firstItem="s7S-kb-ffn" firstAttribute="baseline" secondItem="pQa-uc-wPG" secondAttribute="baseline" id="xVj-oI-eOv"/>
                                     </constraints>
                                 </view>
                                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="1cB-Ww-mg4" userLabel="Bottom Line">
@@ -189,7 +181,6 @@
                         <outlet property="emailLabel" destination="V8B-Yh-Nqr" id="TA1-Kk-gQe"/>
                         <outlet property="leaveStudyButton" destination="z1W-30-kzX" id="RgD-KV-S1x"/>
                         <outlet property="nameLabel" destination="a7q-VX-kPu" id="0jE-gQ-9hm"/>
-                        <outlet property="pauseStudyButton" destination="s7S-kb-ffn" id="cfO-Yd-uz4"/>
                         <outlet property="versionLabel" destination="LGM-jD-pfF" id="o2a-N2-PLx"/>
                     </connections>
                 </tableViewController>
@@ -350,11 +341,11 @@
                                 <rect key="frame" x="0.0" y="92" width="375" height="60"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="SzE-ad-pjR" id="Pq3-de-2gL">
-                                    <frame key="frameInset" width="342" height="59"/>
+                                    <frame key="frameInset" width="342" height="59.5"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Title" textAlignment="natural" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="PJf-CV-qWk">
-                                            <frame key="frameInset" minX="57" width="283" height="59"/>
+                                            <frame key="frameInset" minX="57" width="283" height="59.5"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                             <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                             <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>

--- a/BridgeAppSDKSample/BridgeInfo.plist
+++ b/BridgeAppSDKSample/BridgeInfo.plist
@@ -114,5 +114,43 @@
 			<true/>
 		</dict>
 	</array>
+	<key>permissionTypes</key>
+	<array>
+		<dict>
+			<key>identifier</key>
+			<string>healthKit</string>
+			<key>healthKitTypes</key>
+			<array>
+				<dict>
+					<key>profileKey</key>
+					<string>gender</string>
+					<key>identifier</key>
+					<string>HKCharacteristicTypeIdentifierBiologicalSex</string>
+				</dict>
+				<dict>
+					<key>profileKey</key>
+					<string>dateOfBirth</string>
+					<key>identifier</key>
+					<string>HKCharacteristicTypeIdentifierDateOfBirth</string>
+				</dict>
+				<dict>
+					<key>identifier</key>
+					<string>HKQuantityTypeIdentifierHeight</string>
+					<key>profileKey</key>
+					<string>height</string>
+				</dict>
+				<dict>
+					<key>identifier</key>
+					<string>HKQuantityTypeIdentifierBodyMass</string>
+					<key>profileKey</key>
+					<string>bodyMass</string>
+				</dict>
+				<string>HKQuantityTypeIdentifierStepCount</string>
+			</array>
+		</dict>
+		<string>notifications</string>
+		<string>coremotion</string>
+		<string>microphone</string>
+	</array>
 </dict>
 </plist>

--- a/BridgeAppSDKSample/Info.plist
+++ b/BridgeAppSDKSample/Info.plist
@@ -2,6 +2,10 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSHealthUpdateUsageDescription</key>
+	<string>This app would like to write to your health data in order to update your demographic information.</string>
+	<key>NSHealthShareUsageDescription</key>
+	<string>This app would like to read your heath data in order to get demographic information and activity collected by your other apps.</string>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleDisplayName</key>

--- a/BridgeAppSDKSample/StudyOverviewViewController.swift
+++ b/BridgeAppSDKSample/StudyOverviewViewController.swift
@@ -62,7 +62,6 @@ class StudyOverviewViewController: UIViewController, ORKTaskViewControllerDelega
         // Create a task with an external ID and permissions steps and display the view controller
         let externalIDStep = SBAExternalIDStep(identifier: "externalID")
         let permissonsStep = SBAPermissionsStep(identifier: "permissions")
-        permissonsStep.permissions = appDelegate.requiredPermissions
         let task = ORKOrderedTask(identifier: "registration", steps: [externalIDStep, permissonsStep])
         let vc = SBATaskViewController(task: task, taskRun: nil)
         vc.delegate = self

--- a/BridgeAppSDKTests/SBAAccountTests.swift
+++ b/BridgeAppSDKTests/SBAAccountTests.swift
@@ -154,11 +154,14 @@ class SBAAccountTests: XCTestCase {
     // MARK: Permissions
     
     func testPermssionsType_Some() {
-        let permissonsStep = SBAPermissionsStep(identifier: "permissions")
-        permissonsStep.permissions = [.coremotion, .localNotifications, .microphone]
+        let permissionsStep = SBAPermissionsStep(identifier: "permissions",
+                                                permissions: [.coremotion, .notifications, .microphone])
         
-        let expectedItems = [SBAPermissionsType.coremotion.rawValue, SBAPermissionsType.localNotifications.rawValue, SBAPermissionsType.microphone.rawValue].sorted()
-        let actualItems = permissonsStep.items as? [UInt]
+        let expectedItems = [SBAPermissionObjectType(permissionType: .coremotion),
+                             SBANotificationPermissionObjectType(permissionType: .notifications),
+                             SBAPermissionObjectType(permissionType: .microphone)]
+        
+        let actualItems = permissionsStep.items as? [SBAPermissionObjectType]
         
         XCTAssertNotNil(actualItems)
         guard actualItems != nil else { return }
@@ -166,11 +169,39 @@ class SBAAccountTests: XCTestCase {
     }
     
     func testPermssionsType_PhotoLibrary() {
-        let permissonsStep = SBAPermissionsStep(identifier: "permissions")
-        permissonsStep.permissions = [.photoLibrary]
+        let permissionsStep = SBAPermissionsStep(identifier: "permissions",
+                                                permissions: [.photoLibrary])
         
-        let expectedItems = [SBAPermissionsType.photoLibrary.rawValue].sorted()
-        let actualItems = permissonsStep.items as? [UInt]
+        let expectedItems = [SBAPermissionObjectType(permissionType: .photoLibrary)]
+        let actualItems = permissionsStep.items as? [SBAPermissionObjectType]
+        
+        XCTAssertNotNil(actualItems)
+        guard actualItems != nil else { return }
+        XCTAssertEqual(actualItems!, expectedItems)
+    }
+    
+    func testPermissionsType_InputItem() {
+        
+        let inputItem: NSDictionary =      [
+            "identifier"   : "permissions",
+            "type"         : "permissions",
+            "title"        : "Permissions",
+            "text"         : "The following permissions are required for this activity. Please change these permissions via the iPhone Settings app before continuing.",
+            "items"        : ["coremotion", "microphone"],
+            "optional"     : false,
+        ]
+        let step = SBAPermissionsStep(inputItem: inputItem)
+        
+        XCTAssertNotNil(step)
+        guard let permissionsStep = step else { return }
+        
+        XCTAssertEqual(permissionsStep.identifier, "permissions")
+        XCTAssertFalse(permissionsStep.isOptional)
+        XCTAssertEqual(permissionsStep.title, "Permissions")
+        XCTAssertEqual(permissionsStep.text, "The following permissions are required for this activity. Please change these permissions via the iPhone Settings app before continuing.")
+        
+        let expectedItems = [SBAPermissionObjectType(permissionType: .coremotion), SBAPermissionObjectType(permissionType: .microphone)]
+        let actualItems = permissionsStep.items as? [SBAPermissionObjectType]
         
         XCTAssertNotNil(actualItems)
         guard actualItems != nil else { return }

--- a/BridgeAppSDKTests/SBAOnboardingManagerTests.swift
+++ b/BridgeAppSDKTests/SBAOnboardingManagerTests.swift
@@ -182,7 +182,7 @@ class SBAOnboardingManagerTests: ResourceTestCase {
 
         guard let steps = checkOnboardingSteps( .base(.eligibility), .registration) else { return }
         
-        let expectedSteps: [ORKStep] = [SBANavigationFormStep(identifier: "inclusionCriteria"),
+        let expectedSteps: [ORKStep] = [SBAToggleFormStep(identifier: "inclusionCriteria"),
                                         SBAInstructionStep(identifier: "ineligibleInstruction"),
                                         SBAInstructionStep(identifier: "eligibleInstruction")]
         XCTAssertEqual(steps.count, expectedSteps.count)

--- a/BridgeAppSDKTests/SBAScheduledActivityManagerTests.swift
+++ b/BridgeAppSDKTests/SBAScheduledActivityManagerTests.swift
@@ -975,6 +975,7 @@ class TestScheduledActivityManager: SBAScheduledActivityManager, SBABridgeInfo {
     var logoImageName: String?
     var appUpdateURLString: String?
     var disableTestUserCheck: Bool = false
+    var permissionTypeItems: [Any]?
     
     let medTaskRef = [
         "taskIdentifier"    : medicationTrackingTaskId,

--- a/BridgeAppSDKTests/SBAUserTests.swift
+++ b/BridgeAppSDKTests/SBAUserTests.swift
@@ -79,6 +79,7 @@ class MockBridgeInfo : NSObject, SBABridgeInfo {
     var logoImageName: String?
     var appUpdateURLString: String?
     var disableTestUserCheck: Bool = false
+    var permissionTypeItems: [Any]?
 }
 
 class MockAuthManager: NSObject, SBBAuthManagerProtocol {


### PR DESCRIPTION
@EricSiegNW 
@Erin-Mounts 

Let me know if you want a tour. It's a fairly substantial refactor and was a bit complicated to setup to allow reverse-compatibility which I felt was important given that we now have a couple of folks (other than us) who are using this SDK.

Basically, this replaces a simple enum with an object that can carry additional information. Some extensions are defined but there is still work to allow remote notifications handling and probably some other things.