### PR TITLE
Change account management steps to use protocols

### DIFF
--- a/BridgeAppSDK.xcodeproj/project.pbxproj
+++ b/BridgeAppSDK.xcodeproj/project.pbxproj
@@ -162,6 +162,7 @@
 		FF78CF891D00F3DB002C456D /* EligibilityRequirements.json in Resources */ = {isa = PBXBuildFile; fileRef = FF78CF881D00F3DB002C456D /* EligibilityRequirements.json */; };
 		FF78CF9F1D0144BF002C456D /* SBARegistrationStep.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF78CF9E1D0144BF002C456D /* SBARegistrationStep.swift */; };
 		FF80920F1D01FD35003FF617 /* ORKAnswerFormat+KeyboardUtilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF80920E1D01FD35003FF617 /* ORKAnswerFormat+KeyboardUtilities.swift */; };
+		FF812A251DDCEC6700A61655 /* SBAChangeEmailStep.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF812A241DDCEC6700A61655 /* SBAChangeEmailStep.swift */; };
 		FF8359231D6FACED0028B899 /* SBADirectNavigationRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF8359221D6FACED0028B899 /* SBADirectNavigationRule.swift */; };
 		FF84AB661D90A7D900ABD54C /* HealthKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FF84AB651D90A7D900ABD54C /* HealthKit.framework */; };
 		FF89975A1D0B3B9800B26051 /* MockAppInfoDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = FF8997591D0B3B9800B26051 /* MockAppInfoDelegate.m */; };
@@ -571,6 +572,7 @@
 		FF78CF881D00F3DB002C456D /* EligibilityRequirements.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = EligibilityRequirements.json; sourceTree = "<group>"; };
 		FF78CF9E1D0144BF002C456D /* SBARegistrationStep.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = SBARegistrationStep.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		FF80920E1D01FD35003FF617 /* ORKAnswerFormat+KeyboardUtilities.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ORKAnswerFormat+KeyboardUtilities.swift"; sourceTree = "<group>"; };
+		FF812A241DDCEC6700A61655 /* SBAChangeEmailStep.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SBAChangeEmailStep.swift; sourceTree = "<group>"; };
 		FF8359221D6FACED0028B899 /* SBADirectNavigationRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SBADirectNavigationRule.swift; sourceTree = "<group>"; };
 		FF84AB651D90A7D900ABD54C /* HealthKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = HealthKit.framework; path = System/Library/Frameworks/HealthKit.framework; sourceTree = SDKROOT; };
 		FF8997581D0B3B9800B26051 /* MockAppInfoDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MockAppInfoDelegate.h; sourceTree = "<group>"; };
@@ -1029,6 +1031,7 @@
 			children = (
 				FFDECE071D08D0BC00434001 /* SBAConsentReviewStep.swift */,
 				FF9707F51DA6D5DB006E8252 /* SBAConsentSharingStep.swift */,
+				FF812A241DDCEC6700A61655 /* SBAChangeEmailStep.swift */,
 				FFDECE051D08901300434001 /* SBAEmailVerificationStep.swift */,
 				FF30E5BA1CF76CBA003C0F8F /* SBAExternalIDStep.swift */,
 				FFDECE031D088FA600434001 /* SBALoginStep.swift */,
@@ -1918,6 +1921,7 @@
 				FBE1A9651CAB322700F1F584 /* SBAActiveTask.swift in Sources */,
 				FBAD116E1CADE55C005611D0 /* SBABridgeTask.swift in Sources */,
 				FF5E56E81D6F8941008BA2A8 /* SBATaskViewController.swift in Sources */,
+				FF812A251DDCEC6700A61655 /* SBAChangeEmailStep.swift in Sources */,
 				FFB30E3A1D488F4800D175D2 /* SBALoadingView.swift in Sources */,
 				FFCF385D1CE1172A0090452F /* NSPredicate+Utilities.swift in Sources */,
 				FF2379AC1CBC41C000F3A943 /* SBATrackedDataObjectCollection.m in Sources */,

--- a/BridgeAppSDK/SBAEmailVerificationStep.swift
+++ b/BridgeAppSDK/SBAEmailVerificationStep.swift
@@ -144,9 +144,13 @@ open class SBAEmailVerificationStepViewController: SBAInstructionStepViewControl
     }
     
     func handleWrongEmailAction() {
-        let task = ORKOrderedTask(identifier: "changeEmail", steps: [SBAChangeEmailStep(identifier: "changeEmail")])
+        let task = ORKOrderedTask(identifier: "changeEmail", steps: [instantiateChangeEmailStep()])
         let taskVC = SBATaskViewController(task: task, taskRun: nil)
         self.present(taskVC, animated: true, completion: nil)
+    }
+    
+    open func instantiateChangeEmailStep() -> ORKStep {
+        return SBAChangeEmailStep(identifier: "changeEmail")
     }
     
     func handleResendEmailAction() {
@@ -193,57 +197,5 @@ open class SBAEmailVerificationLearnMoreAction: SBALearnMoreAction {
     
 }
 
-class SBAChangeEmailStep: ORKFormStep {
-    
-    override init(identifier: String) {
-        super.init(identifier: identifier)
-        let profileInfo = SBAProfileInfoOptions(includes: [.email])
-        self.title = Localization.localizedString("REGISTRATION_CHANGE_EMAIL_TITLE")
-        self.formItems = profileInfo.makeFormItems(surveyItemType: .account(.emailVerification))
-        self.isOptional = false
-    }
-    
-    required init(coder aDecoder: NSCoder) {
-        super.init(coder: aDecoder)
-    }
 
-    override func stepViewControllerClass() -> AnyClass {
-        return SBAChangeEmailStepViewController.classForCoder()
-    }
-}
-
-open class SBAChangeEmailStepViewController: ORKFormStepViewController, SBAUserProfileController {
-    
-    // MARK: SBASharedInfoController
-    
-    lazy public var sharedAppDelegate: SBAAppInfoDelegate = {
-        return UIApplication.shared.delegate as! SBAAppInfoDelegate
-    }()
-    
-    // MARK: SBAUserProfileController
-    
-    open var failedValidationMessage = Localization.localizedString("SBA_REGISTRATION_UNKNOWN_FAILED")
-    open var failedRegistrationTitle = Localization.localizedString("SBA_REGISTRATION_FAILED_TITLE")
-    
-    
-    // Override the default method for goForward and attempt changing email. 
-    // Do not allow subclasses to override this method
-    final public override func goForward() {
-        showLoadingView()
-        sharedUser.changeUserEmailAddress(email!) { [weak self] error in
-            if let error = error {
-                self?.handleFailedRegistration(error)
-            }
-            else {
-                self?.goNext()
-            }
-        }
-    }
-    
-    open func goNext() {
-        // Then call super to go forward
-        super.goForward()
-    }
-
-}
 

--- a/BridgeAppSDK/SBAUserProfileController.swift
+++ b/BridgeAppSDK/SBAUserProfileController.swift
@@ -33,10 +33,12 @@
 
 import Foundation
 
-public protocol SBAUserProfileController: class, SBASharedInfoController, SBAAlertPresenter, SBALoadingViewPresenter {
+public protocol SBAStepViewControllerProtocol: class, SBASharedInfoController, SBAAlertPresenter, SBALoadingViewPresenter {
     
     var result: ORKStepResult? { get }
-    
+}
+
+public protocol SBAUserProfileController: SBAStepViewControllerProtocol {
     var failedValidationMessage: String { get }
     var failedRegistrationTitle: String { get }
 }


### PR DESCRIPTION
Some of the steps in the account management inherit from ORKQuestionStepViewController or ORKFormStepViewController. Change these to use protocol extensions in order to allow the step view controller to *not* inherit from these view controllers.