### PR TITLE
Feature/make more methods accessible

### DIFF
--- a/BridgeAppSDK/SBAEmailVerificationStep.swift
+++ b/BridgeAppSDK/SBAEmailVerificationStep.swift
@@ -143,7 +143,7 @@ open class SBAEmailVerificationStepViewController: SBAInstructionStepViewControl
         // Do nothing
     }
     
-    func handleWrongEmailAction() {
+    open func handleWrongEmailAction() {
         let task = ORKOrderedTask(identifier: "changeEmail", steps: [instantiateChangeEmailStep()])
         let taskVC = SBATaskViewController(task: task, taskRun: nil)
         self.present(taskVC, animated: true, completion: nil)
@@ -153,7 +153,7 @@ open class SBAEmailVerificationStepViewController: SBAInstructionStepViewControl
         return SBAChangeEmailStep(identifier: "changeEmail")
     }
     
-    func handleResendEmailAction() {
+    open func handleResendEmailAction() {
         showLoadingView()
         sharedUser.resendVerificationEmail { [weak self] (error) in
             if let error = error {

--- a/BridgeAppSDK/SBAUserProfileController.swift
+++ b/BridgeAppSDK/SBAUserProfileController.swift
@@ -127,14 +127,14 @@ extension SBAUserProfileController {
     
     // MARK: Error handling
 
-    public func handleFailedValidation(_ reason: String? = nil) {
+    func handleFailedValidation(_ reason: String? = nil) {
         let message = reason ?? failedValidationMessage
         self.hideLoadingView({ [weak self] in
             self?.showAlertWithOk(title: self?.failedRegistrationTitle, message: message, actionHandler: nil)
             })
     }
     
-    public func handleFailedRegistration(_ error: Error) {
+    func handleFailedRegistration(_ error: Error) {
         let message = (error as NSError).localizedBridgeErrorMessage
         handleFailedValidation(message)
     }

--- a/BridgeAppSDK/SBAUserProfileController.swift
+++ b/BridgeAppSDK/SBAUserProfileController.swift
@@ -155,14 +155,14 @@ extension SBAUserProfileController {
     
     // MARK: Error handling
 
-    func handleFailedValidation(_ reason: String? = nil) {
+    public func handleFailedValidation(_ reason: String? = nil) {
         let message = reason ?? failedValidationMessage
         self.hideLoadingView({ [weak self] in
             self?.showAlertWithOk(title: self?.failedRegistrationTitle, message: message, actionHandler: nil)
             })
     }
     
-    func handleFailedRegistration(_ error: Error) {
+    public func handleFailedRegistration(_ error: Error) {
         let message = (error as NSError).localizedBridgeErrorMessage
         handleFailedValidation(message)
     }


### PR DESCRIPTION
Add open to handleWrongEmailAction and handleResendEmail action so we can call these explicitly from sub classes. In our case we want to tie them to button actions specific to our UI rather than the alert approach used in the BridgeAppSDK.