### PR TITLE
Add keychain to BridgeAppSDK that can set access group and service.

### DIFF
--- a/BridgeAppSDK.xcodeproj/project.pbxproj
+++ b/BridgeAppSDK.xcodeproj/project.pbxproj
@@ -249,6 +249,8 @@
 		FFC160A61CFE67B600C29AF7 /* ResearchKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FFC1609F1CFE672100C29AF7 /* ResearchKit.framework */; };
 		FFC160A71CFE69DB00C29AF7 /* ZipZap.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FFC160781CFE672100C29AF7 /* ZipZap.framework */; };
 		FFC160DB1CFE6E1000C29AF7 /* openssl.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FFC160CE1CFE6DC300C29AF7 /* openssl.framework */; };
+		FFC41F4D1E025DBC0057526E /* SBAKeychainWrapper.h in Headers */ = {isa = PBXBuildFile; fileRef = FFC41F4B1E025DBC0057526E /* SBAKeychainWrapper.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		FFC41F4E1E025DBC0057526E /* SBAKeychainWrapper.m in Sources */ = {isa = PBXBuildFile; fileRef = FFC41F4C1E025DBC0057526E /* SBAKeychainWrapper.m */; };
 		FFCB98871CAC9000005078EF /* DeprecationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFCB98861CAC9000005078EF /* DeprecationTests.swift */; };
 		FFCF37741CD41A920090452F /* SBAScheduledActivityManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFCF37731CD41A920090452F /* SBAScheduledActivityManagerTests.swift */; };
 		FFCF37B21CD94EC80090452F /* ORKOrderedTask+SBAExtension.h in Headers */ = {isa = PBXBuildFile; fileRef = FFCF37B01CD94EC80090452F /* ORKOrderedTask+SBAExtension.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -671,6 +673,8 @@
 		FFC15FD91CFE4E8700C29AF7 /* BridgeInfo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = BridgeInfo.plist; sourceTree = "<group>"; };
 		FFC15FDB1CFE4F0D00C29AF7 /* ColorInfo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = ColorInfo.plist; sourceTree = "<group>"; };
 		FFC15FDE1CFE513200C29AF7 /* sample-study.pem */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = "sample-study.pem"; sourceTree = "<group>"; };
+		FFC41F4B1E025DBC0057526E /* SBAKeychainWrapper.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SBAKeychainWrapper.h; sourceTree = "<group>"; };
+		FFC41F4C1E025DBC0057526E /* SBAKeychainWrapper.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SBAKeychainWrapper.m; sourceTree = "<group>"; };
 		FFCB98861CAC9000005078EF /* DeprecationTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DeprecationTests.swift; sourceTree = "<group>"; };
 		FFCF37731CD41A920090452F /* SBAScheduledActivityManagerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SBAScheduledActivityManagerTests.swift; sourceTree = "<group>"; };
 		FFCF37B01CD94EC80090452F /* ORKOrderedTask+SBAExtension.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "ORKOrderedTask+SBAExtension.h"; sourceTree = "<group>"; };
@@ -940,6 +944,7 @@
 				FF6410F91CAF39B4007FB9E1 /* String+Utilities.swift */,
 				FF9E48951CF3A2F1005EE7E0 /* StaticUtilities.swift */,
 				FBF1B6B21CAAF6FC007C1082 /* UIAlertController+Utilities.swift */,
+				FFC41F331E025DA50057526E /* Keychain */,
 				FF63D0F51CD03297007ADEE5 /* Logging */,
 				FBAE3CF01C861587003CEC4A /* PDF */,
 			);
@@ -1494,6 +1499,15 @@
 			name = Products;
 			sourceTree = "<group>";
 		};
+		FFC41F331E025DA50057526E /* Keychain */ = {
+			isa = PBXGroup;
+			children = (
+				FFC41F4B1E025DBC0057526E /* SBAKeychainWrapper.h */,
+				FFC41F4C1E025DBC0057526E /* SBAKeychainWrapper.m */,
+			);
+			name = Keychain;
+			sourceTree = "<group>";
+		};
 		FFCF38FF1CE267630090452F /* Result */ = {
 			isa = PBXGroup;
 			children = (
@@ -1517,6 +1531,7 @@
 				FF8DDFD51CB62280006D1AFA /* SBATrackedDataStore.h in Headers */,
 				FF722C151D775BB8004B2F8B /* SBANewsFeedManager.h in Headers */,
 				FFAAF61E1CC0267E00500929 /* SBAPermissionsManager.h in Headers */,
+				FFC41F4D1E025DBC0057526E /* SBAKeychainWrapper.h in Headers */,
 				FF722C191D775C55004B2F8B /* SBANewsFeedItem.h in Headers */,
 				FF45F84B1CA5D61900EE0562 /* SBABridgeManager.h in Headers */,
 				FF64111B1CB34766007FB9E1 /* SBAMedication.h in Headers */,
@@ -1973,6 +1988,7 @@
 				FF78CF9F1D0144BF002C456D /* SBARegistrationStep.swift in Sources */,
 				FF5242B11D81E9D0009043B3 /* SBAUserProfileController.swift in Sources */,
 				FF63D0FD1CD03DCA007ADEE5 /* SBADataArchive.m in Sources */,
+				FFC41F4E1E025DBC0057526E /* SBAKeychainWrapper.m in Sources */,
 				FF8DDFD61CB62280006D1AFA /* SBATrackedDataStore.m in Sources */,
 				FB6BA0971C7CDB2600C9903F /* SBASubtaskStep.swift in Sources */,
 				FF21DE701DDBDA4A00C0B181 /* SBADemographicDataArchive.swift in Sources */,

--- a/BridgeAppSDK/BridgeAppSDK.h
+++ b/BridgeAppSDK/BridgeAppSDK.h
@@ -45,6 +45,7 @@ FOUNDATION_EXPORT const unsigned char BridgeAppSDKVersionString[];
 #import <BridgeAppSDK/SBADataObject.h>
 #import <BridgeAppSDK/SBADemographicDataObjectType.h>
 #import <BridgeAppSDK/SBAJSONObject.h>
+#import <BridgeAppSDK/SBAKeychainWrapper.h>
 #import <BridgeAppSDK/SBALog.h>
 #import <BridgeAppSDK/SBAMedication.h>
 #import <BridgeAppSDK/SBANewsFeedItem.h>

--- a/BridgeAppSDK/SBABridgeInfo.swift
+++ b/BridgeAppSDK/SBABridgeInfo.swift
@@ -120,6 +120,16 @@ public protocol SBABridgeInfo: class {
      Array of objects that can be converted into `SBAPermissionObjectType` objects.
     */
     var permissionTypeItems: [Any]? { get }
+    
+    /**
+     Keychain service name.
+     */
+    var keychainService: String? { get }
+    
+    /**
+    Keychain access group name.
+    */
+    var keychainAccessGroup: String? { get }
 }
 
 /**
@@ -218,6 +228,14 @@ public final class SBABridgeInfoPList : NSObject, SBABridgeInfo {
     
     public var permissionTypeItems: [Any]? {
         return self.plist["permissionTypes"] as? [Any]
+    }
+    
+    public var keychainService: String? {
+        return self.plist["keychainService"] as? String
+    }
+    
+    public var keychainAccessGroup: String? {
+        return self.plist["keychainAccessGroup"] as? String
     }
 }
 

--- a/BridgeAppSDK/SBAKeychainWrapper.h
+++ b/BridgeAppSDK/SBAKeychainWrapper.h
@@ -1,0 +1,116 @@
+
+//  Copyright (c) 2015, Apple Inc. All rights reserved.
+//  Copyright © 2016 Sage Bionetworks. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification,
+// are permitted provided that the following conditions are met:
+//
+// 1.  Redistributions of source code must retain the above copyright notice, this
+// list of conditions and the following disclaimer.
+//
+// 2.  Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation and/or
+// other materials provided with the distribution.
+//
+// 3.  Neither the name of the copyright holder(s) nor the names of any contributors
+// may be used to endorse or promote products derived from this software without
+// specific prior written permission. No license is granted to the trademarks of
+// the copyright holders even if such marks are included in this software.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+
+@import Foundation;
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ The `SBAKeychainWrapper` class is an abstraction layer for the iOS keychain
+ communication.
+ 
+ This version is modified from ResearchKit's ORKKeychainWrapper to allow for 
+ reverse-compatibility to ResearchKit with modifications to support use of
+ an access group.
+ */
+
+@interface SBAKeychainWrapper : NSObject
+
+/**
+ Value for kSecAttrService. `default = [[NSBundle mainBundle] bundleIdentifier]`
+ */
+@property (nonatomic, copy, readonly) NSString *service;
+
+/**
+ Value for kSecAttrAccessGroup. `default = nil`
+ See http://evgenii.com/blog/sharing-keychain-in-ios/ for a good explanation for how to set up 
+ shared keychain access.
+ */
+@property (nonatomic, copy, readonly, nullable) NSString *accessGroup;
+
+/**
+ Designated initializer includes setting the service and access group. If the `service` is `nil` then
+ it will be set to the default.
+ */
+- (instancetype)initWithService:(NSString * _Nullable)service accessGroup:(NSString * _Nullable)accessGroup NS_DESIGNATED_INITIALIZER;
+
+/**
+ Sets the given object in the keychain for the provided key.
+ 
+ @param object      The data to be stored in the keychain.
+ @param key         The key used to set the data in the keychain.
+ @param error       If failure occurred, an `NSError` object indicating the reason for the
+                    failure. The value of this parameter is `nil` if `result` does not
+                    indicate failure.
+ 
+ @return A boolean with a value `YES` if the object was saved; otherwise `NO'.
+ */
+- (BOOL)setObject:(id<NSSecureCoding>)object forKey:(NSString *)key error:(NSError * _Nullable *)error;
+
+
+/**
+ Returns the object in the keychain for the provided key.
+ 
+ @param key         The key used to set the data in the keychain.
+ @param error       If failure occurred, an `NSError` object indicating the reason for the
+                    failure. The value of this parameter is `nil` if `result` does not
+                    indicate failure.
+ 
+ @return An object or `nil` if key is not valid.
+ */
+- (id<NSSecureCoding>)objectForKey:(NSString *)key error:(NSError * _Nullable *)error;
+
+/**
+ Removes the object in the keychain for the provided key.
+ 
+ @param key         The key used to set the value in the keychain.
+ @param error       If failure occurred, an `NSError` object indicating the reason for the
+                    failure. The value of this parameter is `nil` if `result` does not
+                    indicate failure.
+ 
+ @return A boolean with a value `YES` if the object was removed; otherwise `NO'.
+*/
+- (BOOL)removeObjectForKey:(NSString *)key error:(NSError * _Nullable *)error;
+
+/**
+ Removes all values stored in the keychain for the app.
+
+ @param error       If failure occurred, an `NSError` object indicating the reason for the
+                    failure. The value of this parameter is `nil` if `result` does not
+                    indicate failure.
+ 
+ @return A boolean with a value `YES` if the keychain was reset; otherwise `NO'.
+*/
+- (BOOL)resetKeychainWithError:(NSError * _Nullable *)error;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/BridgeAppSDK/SBAKeychainWrapper.m
+++ b/BridgeAppSDK/SBAKeychainWrapper.m
@@ -1,0 +1,317 @@
+ /**
+ Copyright (c) 2015, Apple Inc. All rights reserved. 
+ 
+ Redistribution and use in source and binary forms, with or without modification,
+ are permitted provided that the following conditions are met:
+ 
+ 1.  Redistributions of source code must retain the above copyright notice, this
+ list of conditions and the following disclaimer.
+ 
+ 2.  Redistributions in binary form must reproduce the above copyright notice, 
+ this list of conditions and the following disclaimer in the documentation and/or 
+ other materials provided with the distribution. 
+ 
+ 3.  Neither the name of the copyright holder(s) nor the names of any contributors 
+ may be used to endorse or promote products derived from this software without 
+ specific prior written permission. No license is granted to the trademarks of 
+ the copyright holders even if such marks are included in this software. 
+ 
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
+ AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+ IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
+ ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE 
+ FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL 
+ DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
+ SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
+ CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, 
+ OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
+ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
+ */
+
+
+#import "SBAKeychainWrapper.h"
+#import <BridgeAppSDK/BridgeAppSDK-Swift.h>
+
+static NSString *SBAKeychainWrapperDefaultService() {
+    static NSString *defaultService;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        defaultService = [[NSBundle mainBundle] bundleIdentifier];
+    });
+    return defaultService;
+}
+
+@implementation SBAKeychainWrapper
+
+#pragma mark - Public Methods
+
+- (instancetype)init {
+    return [self initWithService:nil accessGroup:nil];
+}
+
+- (instancetype)initWithService:(NSString * _Nullable)service accessGroup:(NSString * _Nullable)accessGroup {
+    self = [super init];
+    if (self) {
+        _service = [service copy] ?: SBAKeychainWrapperDefaultService();
+        _accessGroup = [accessGroup copy];
+    }
+    return self;
+}
+
+- (BOOL)setObject:(id<NSSecureCoding>)object
+           forKey:(NSString *)key
+            error:(NSError **)error {
+    NSData *data = [NSKeyedArchiver archivedDataWithRootObject:object];
+    return [self setData:data
+                  forKey:key
+                 service:self.service
+             accessGroup:self.accessGroup
+                   error:error];
+}
+
+- (id<NSSecureCoding>)objectForKey:(NSString *)key
+             error:(NSError **)error {
+    NSData *data = [self dataForKey:key
+                            service:self.service
+                        accessGroup:self.accessGroup
+                              error:error];
+    return data ? [NSKeyedUnarchiver unarchiveObjectWithData:data] : nil;
+}
+
+- (BOOL)removeObjectForKey:(NSString *)key
+                     error:(NSError **)error {
+    return [self removeItemForKey:key
+                          service:self.service
+                      accessGroup:self.accessGroup
+                            error:error];
+}
+
+- (BOOL)resetKeychainWithError:(NSError **)error {
+    
+    // Clear the keychain and access group associated with this keychain
+    BOOL success = [self removeAllItemsForService:self.service
+                                      accessGroup:self.accessGroup
+                                            error:error];
+    
+    // Also clear the default service keychain which is used by ResearchKit to store
+    // the passcode and might contain old data.
+    if (success && ![self.service isEqualToString:SBAKeychainWrapperDefaultService()]) {
+        success = [self removeAllItemsForService:SBAKeychainWrapperDefaultService()
+                                     accessGroup:nil
+                                           error:error];
+    }
+    return success;
+}
+
+#pragma mark - Private Methods
+
+- (NSData *)dataForKey:(NSString *)key
+               service:(NSString *)service
+           accessGroup:(NSString *)accessGroup
+                 error:(NSError **)error {
+    NSData *returnValue = nil;
+    if (key) {
+        if (!service) {
+            service = SBAKeychainWrapperDefaultService();
+        }
+        
+        NSMutableDictionary *query = [[NSMutableDictionary alloc] init];
+        [query setObject:(__bridge id)kSecClassGenericPassword forKey:(__bridge id)kSecClass];
+        [query setObject:(__bridge id)kCFBooleanTrue forKey:(__bridge id)kSecReturnData];
+        [query setObject:(__bridge id)kSecMatchLimitOne forKey:(__bridge id)kSecMatchLimit];
+        [query setObject:service forKey:(__bridge id)kSecAttrService];
+        [query setObject:key forKey:(__bridge id)kSecAttrAccount];
+#if !TARGET_IPHONE_SIMULATOR && defined(__IPHONE_OS_VERSION_MIN_REQUIRED)
+        if (accessGroup) {
+            [query setObject:accessGroup forKey:(__bridge id)kSecAttrAccessGroup];
+        }
+#endif
+        
+        CFTypeRef data = nil;
+        OSStatus status = SecItemCopyMatching((__bridge CFDictionaryRef)query, &data);
+        if (status != errSecSuccess) {
+            if (error) {
+                *error = [NSError errorWithDomain:NSOSStatusErrorDomain
+                                             code:status
+                                         userInfo:@{NSLocalizedDescriptionKey: [Localization localizedString:@"KEYCHAIN_FIND_ERROR_MESSAGE"]}];
+            }
+        } else {
+            returnValue = [NSData dataWithData:(__bridge NSData *)data];
+            if (data) {
+                CFRelease(data);
+            }
+        }
+    }
+    return returnValue;
+}
+
+- (BOOL)setData:(NSData *)data
+         forKey:(NSString *)key
+        service:(NSString *)service
+    accessGroup:(NSString *)accessGroup
+          error:(NSError **)error {
+    BOOL returnValue = YES;
+    if (key) {
+        if (!service) {
+            service = SBAKeychainWrapperDefaultService();
+        }
+        
+        NSMutableDictionary *query = [[NSMutableDictionary alloc] init];
+        [query setObject:(__bridge id)kSecClassGenericPassword forKey:(__bridge id)kSecClass];
+        [query setObject:service forKey:(__bridge id)kSecAttrService];
+        [query setObject:key forKey:(__bridge id)kSecAttrAccount];
+#if !TARGET_IPHONE_SIMULATOR && defined(__IPHONE_OS_VERSION_MIN_REQUIRED)
+        if (accessGroup) {
+            [query setObject:accessGroup forKey:(__bridge id)kSecAttrAccessGroup];
+        }
+#endif
+        
+        OSStatus status = SecItemCopyMatching((__bridge CFDictionaryRef)query, NULL);
+        if (status == errSecSuccess) {
+            if (data) {
+                NSMutableDictionary *attributesToUpdate = [[NSMutableDictionary alloc] init];
+                [attributesToUpdate setObject:data forKey:(__bridge id)kSecValueData];
+                
+                status = SecItemUpdate((__bridge CFDictionaryRef)query, (__bridge CFDictionaryRef)attributesToUpdate);
+                if (status != errSecSuccess) {
+                    if (error) {
+                        *error = [NSError errorWithDomain:NSOSStatusErrorDomain
+                                                     code:status
+                                                 userInfo:@{NSLocalizedDescriptionKey: [Localization localizedString:@"KEYCHAIN_UPDATE_ERROR_MESSAGE"]}];
+                    }
+                    returnValue = NO;
+                }
+            } else {
+                [self removeItemForKey:key service:service accessGroup:accessGroup error:error];
+            }
+        } else if (status == errSecItemNotFound) {
+            NSMutableDictionary *attributes = [[NSMutableDictionary alloc] init];
+            [attributes setObject:(__bridge id)kSecClassGenericPassword forKey:(__bridge id)kSecClass];
+            [attributes setObject:service forKey:(__bridge id)kSecAttrService];
+            [attributes setObject:key forKey:(__bridge id)kSecAttrAccount];
+#if TARGET_OS_IPHONE || (defined(MAC_OS_X_VERSION_10_9) && MAC_OS_X_VERSION_MIN_REQUIRED >= MAC_OS_X_VERSION_10_9)
+            [attributes setObject:(__bridge id)kSecAttrAccessibleAfterFirstUnlock forKey:(__bridge id)kSecAttrAccessible];
+#endif
+            [attributes setObject:data forKey:(__bridge id)kSecValueData];
+#if !TARGET_IPHONE_SIMULATOR && defined(__IPHONE_OS_VERSION_MIN_REQUIRED)
+            if (accessGroup) {
+                [attributes setObject:accessGroup forKey:(__bridge id)kSecAttrAccessGroup];
+            }
+#endif
+            
+            status = SecItemAdd((__bridge CFDictionaryRef)attributes, NULL);
+            if (status != errSecSuccess) {
+                if (error) {
+                    *error = [NSError errorWithDomain:NSOSStatusErrorDomain
+                                                 code:status
+                                             userInfo:@{NSLocalizedDescriptionKey: [Localization localizedString:@"KEYCHAIN_ADD_ERROR_MESSAGE"]}];
+                }
+                returnValue = NO;
+            }
+        } else {
+            returnValue = NO;
+        }
+    }
+    return returnValue;
+}
+
+- (BOOL)removeItemForKey:(NSString *)key
+                 service:(NSString *)service
+             accessGroup:(NSString *)accessGroup
+                   error:(NSError **)error {
+    BOOL returnValue = NO;
+    if (key) {
+        if (!service) {
+            service = SBAKeychainWrapperDefaultService();
+        }
+        
+        NSMutableDictionary *itemToDelete = [[NSMutableDictionary alloc] init];
+        [itemToDelete setObject:(__bridge id)kSecClassGenericPassword forKey:(__bridge id)kSecClass];
+        [itemToDelete setObject:service forKey:(__bridge id)kSecAttrService];
+        [itemToDelete setObject:key forKey:(__bridge id)kSecAttrAccount];
+#if !TARGET_IPHONE_SIMULATOR && defined(__IPHONE_OS_VERSION_MIN_REQUIRED)
+        if (accessGroup) {
+            [itemToDelete setObject:accessGroup forKey:(__bridge id)kSecAttrAccessGroup];
+        }
+#endif
+        
+        OSStatus status = SecItemDelete((__bridge CFDictionaryRef)itemToDelete);
+        if (status != errSecSuccess && status != errSecItemNotFound) {
+            if (error) {
+                *error = [NSError errorWithDomain:NSOSStatusErrorDomain
+                                             code:status
+                                         userInfo:@{NSLocalizedDescriptionKey: [Localization localizedString:@"KEYCHAIN_DELETE_ERROR_MESSAGE"]}];
+            }
+            returnValue = NO;
+        } else {
+            returnValue = YES;
+        }
+    }
+    return returnValue;
+}
+
+- (BOOL)removeAllItemsForService:(NSString *)service
+                     accessGroup:(NSString *)accessGroup
+                           error:(NSError **)error {
+    NSArray *items = [self itemsForService:service accessGroup:accessGroup error:error];
+    BOOL returnValue = NO;
+    for (NSDictionary *item in items) {
+        NSMutableDictionary *itemToDelete = [[NSMutableDictionary alloc] initWithDictionary:item];
+        [itemToDelete setObject:(__bridge id)kSecClassGenericPassword forKey:(__bridge id)kSecClass];
+        
+        OSStatus status = SecItemDelete((__bridge CFDictionaryRef)itemToDelete);
+        if (status != errSecSuccess) {
+            if (error) {
+                *error = [NSError errorWithDomain:NSOSStatusErrorDomain
+                                             code:status
+                                         userInfo:@{NSLocalizedDescriptionKey: [Localization localizedString:@"KEYCHAIN_DELETE_ERROR_MESSAGE"]}];
+            }
+            returnValue = NO;
+        } else {
+            returnValue = YES;
+        }
+    }
+    return returnValue;
+}
+
+- (NSArray *)itemsForService:(NSString *)service
+                 accessGroup:(NSString *)accessGroup
+                       error:(NSError **)error {
+    if (!service) {
+        service = SBAKeychainWrapperDefaultService();
+    }
+    
+    NSMutableDictionary *query = [[NSMutableDictionary alloc] init];
+    [query setObject:(__bridge id)kSecClassGenericPassword forKey:(__bridge id)kSecClass];
+    [query setObject:(id)kCFBooleanTrue forKey:(__bridge id)kSecReturnAttributes];
+    [query setObject:(id)kCFBooleanTrue forKey:(__bridge id)kSecReturnData];
+    [query setObject:(__bridge id)kSecMatchLimitAll forKey:(__bridge id)kSecMatchLimit];
+    [query setObject:service forKey:(__bridge id)kSecAttrService];
+#if !TARGET_IPHONE_SIMULATOR && defined(__IPHONE_OS_VERSION_MIN_REQUIRED)
+    if (accessGroup) {
+        [query setObject:accessGroup forKey:(__bridge id)kSecAttrAccessGroup];
+    }
+#endif
+    
+    CFTypeRef result = nil;
+    NSArray *returnValue = nil;
+    OSStatus status = SecItemCopyMatching((__bridge CFDictionaryRef)query, &result);
+    if (status == errSecSuccess || status == errSecItemNotFound) {
+        returnValue =  (__bridge NSArray *)(result);
+    } else {
+        if (error) {
+            *error = [NSError errorWithDomain:NSOSStatusErrorDomain
+                                         code:status
+                                     userInfo:@{NSLocalizedDescriptionKey: [Localization localizedString:@"KEYCHAIN_FIND_ERROR_MESSAGE"]}];
+        }
+        returnValue = nil;
+    }
+    
+    if(result) {
+         CFBridgingRelease(result);
+    }
+    
+    return returnValue;
+}
+
+@end


### PR DESCRIPTION
Actually setting up for shared app access to the keychain is complicated. We will want to create documentation to walk new developers who are less comfortable with Apple iOS through the process since they need to include the App ID Prefix from the developer portal.

I chose to move the code into BridgeAppSDK rather than trying to modify either the keychain wrapper in BridgeSDK or ResearchKit because the BridgeSDK wasn’t working (not sure why) and I didn’t want to rely upon the ResearchKit version which might change in ways we cannot control.

Note: This is a direct copy/paste of the ResearchKit version (kept for legacy apps) that was ported from AppCore with RK v1.3. It includes *not* using the access group if running in the simulator so  I am not certain how to make this work with a keyboard extension that is being testing using the simulator.

In order to implement this you will need to do the following:

1. http://evgenii.com/blog/sharing-keychain-in-ios/ has instructions for how to *get* the string for the access group.

2. Once you have the string for your access group, you will want to add the following keys to the BridgeInfo-private.plist file (You do not want to include the App ID Prefix in an open source file):

````
"keychainService" = <shared name for the service>
"keychainAccessGroup" = <access group as defined in the link above>
````