### PR TITLE
Added trailmaking task to the active tasks and result archive.

### DIFF
--- a/BridgeAppSDK/ORKResult+ResultsExtension.swift
+++ b/BridgeAppSDK/ORKResult+ResultsExtension.swift
@@ -74,6 +74,12 @@ private let kSpatialSpanMemoryTouchSampleTargetIndexKey = "MemoryGameTouchSample
 private let kSpatialSpanMemoryTouchSampleLocationKey = "MemoryGameTouchSampleLocation"
 private let kSpatialSpanMemoryTouchSampleIsCorrectKey = "MemoryGameTouchSampleIsCorrect"
 
+private let kTrailmakingTapsKey = "trailmakingTaps"
+private let kTrailmakingNumberOfErrorsKey = "numberOfErrors"
+private let kTrailmakingTapTimestampKey = "timestamp"
+private let kTrailmakingTapIndexKey = "index"
+private let kTrailmakingTapIncorrectKey = "incorrect"
+
 private let QuestionResultQuestionTextKey = "questionText"
 private let QuestionResultQuestionTypeKey = "questionType"
 private let QuestionResultQuestionTypeNameKey = "questionTypeName"
@@ -305,6 +311,25 @@ extension ORKSpatialSpanMemoryResult {
         return  rectangles as NSArray
     }
     
+}
+
+extension ORKTrailmakingResult {
+    
+    override func resultAsDictionary() -> NSMutableDictionary {
+        let result = super.resultAsDictionary()
+        
+        let resultTaps = self.taps.map ({ (tap) -> [String: AnyObject] in
+            return [kTrailmakingTapTimestampKey : NSNumber(value: tap.timestamp),
+                    kTrailmakingTapIndexKey     : NSNumber(value: tap.index),
+                    kTrailmakingTapIncorrectKey : NSNumber(value: tap.incorrect)]
+        })
+        
+        result[kTrailmakingTapsKey] = resultTaps
+        result[kTrailmakingNumberOfErrorsKey] = NSNumber(value: self.numberOfErrors)
+        result[kItemKey] = self.filenameForArchive()
+        
+        return result
+    }
 }
 
 public final class SBAAnswerKeyAndValue: NSObject {

--- a/BridgeAppSDK/ORKResult+ResultsExtension.swift
+++ b/BridgeAppSDK/ORKResult+ResultsExtension.swift
@@ -74,7 +74,7 @@ private let kSpatialSpanMemoryTouchSampleTargetIndexKey = "MemoryGameTouchSample
 private let kSpatialSpanMemoryTouchSampleLocationKey = "MemoryGameTouchSampleLocation"
 private let kSpatialSpanMemoryTouchSampleIsCorrectKey = "MemoryGameTouchSampleIsCorrect"
 
-private let kTrailmakingTapsKey = "trailmakingTaps"
+private let kTrailmakingTapsKey = "taps"
 private let kTrailmakingNumberOfErrorsKey = "numberOfErrors"
 private let kTrailmakingTapTimestampKey = "timestamp"
 private let kTrailmakingTapIndexKey = "index"
@@ -314,6 +314,12 @@ extension ORKSpatialSpanMemoryResult {
 }
 
 extension ORKTrailmakingResult {
+    
+    // Schema mapping in the Researcher UI
+    // trailmaking.json.taps                JSON Table
+    // trailmaking.json.timestamp           Decimal
+    // trailmaking.json.index               Integer
+    // trailmaking.json.numberOfErrors      Integer
     
     override func resultAsDictionary() -> NSMutableDictionary {
         let result = super.resultAsDictionary()

--- a/BridgeAppSDK/SBAActiveTask.swift
+++ b/BridgeAppSDK/SBAActiveTask.swift
@@ -44,6 +44,7 @@ public enum SBAActiveTaskType {
     case walking
     case tremor
     case moodSurvey
+    case trailmaking
     
     init(name: String?) {
         guard let type = name else { self = .custom(nil); return }
@@ -54,6 +55,7 @@ public enum SBAActiveTaskType {
         case "walking"      : self = .walking
         case "tremor"       : self = .tremor
         case "moodSurvey"   : self = .moodSurvey
+        case "trailmaking"  : self = .trailmaking
         default             : self = .custom(name)
         }
     }
@@ -309,6 +311,23 @@ extension SBAActiveTask {
                                                        frequency: frequency,
                                                        customQuestionText: customQuestionText,
                                                        options: options)
+    }
+    
+    func trailmakingTask(_ options: ORKPredefinedTaskOption) -> ORKOrderedTask {
+        
+        let trailType: ORKTrailMakingTypeIdentifier = {
+            guard let trailType = taskOptions?["trailType"] as? String else {
+                return ORKTrailMakingTypeIdentifier.B
+            }
+            return ORKTrailMakingTypeIdentifier(rawValue: trailType)
+        }()
+        let trailmakingInstruction = taskOptions?["trailmakingInstruction"] as? String
+        
+        return ORKOrderedTask.trailmakingTask(withIdentifier: self.schemaIdentifier,
+                                              intendedUseDescription: self.intendedUseDescription,
+                                              trailmakingInstruction: trailmakingInstruction,
+                                              trailType: trailType,
+                                              options: options)
     }
 }
 

--- a/BridgeAppSDK/SBAActiveTask.swift
+++ b/BridgeAppSDK/SBAActiveTask.swift
@@ -141,6 +141,8 @@ extension SBAActiveTask {
             task = tremorTask(predefinedExclusions)
         case .moodSurvey:
             task = moodSurvey(predefinedExclusions)
+        case .trailmaking:
+            task = trailmakingTask(predefinedExclusions)
         default:
             // exit early if not supported by base implementation
             return nil

--- a/BridgeAppSDKSample/BridgeInfo.plist
+++ b/BridgeAppSDKSample/BridgeInfo.plist
@@ -20,6 +20,12 @@
 	<array>
 		<dict>
 			<key>schemaIdentifier</key>
+			<string>Trail Making</string>
+			<key>schemaRevision</key>
+			<integer>1</integer>
+		</dict>
+		<dict>
+			<key>schemaIdentifier</key>
 			<string>Mood Survey</string>
 			<key>schemaRevision</key>
 			<integer>3</integer>
@@ -76,6 +82,12 @@
 			<string>Mood Survey</string>
 			<key>taskType</key>
 			<string>moodSurvey</string>
+		</dict>
+		<dict>
+			<key>taskIdentifier</key>
+			<string>Trail Making</string>
+			<key>taskType</key>
+			<string>trailmaking</string>
 		</dict>
 		<dict>
 			<key>taskIdentifier</key>

--- a/BridgeAppSDKTests/SBAActiveTaskTests.swift
+++ b/BridgeAppSDKTests/SBAActiveTaskTests.swift
@@ -114,6 +114,89 @@ class SBAActiveTaskTests: XCTestCase {
         XCTAssertEqual(completionStep.detailText, "Detail Text 123")
     }
     
+    func testTrailmakingTask() {
+        
+        let inputTask: NSDictionary = [
+            "taskIdentifier"            : "1-Trail-Making",
+            "schemaIdentifier"          : "Trail Making",
+            "taskType"                  : "trailmaking",
+            "intendedUseDescription"    : "intended Use Description Text",
+            "taskOptions"               : [
+                "trailType"                 : "A",
+                "trailmakingInstruction"    : "trail making instruction"
+            ],
+            "localizedSteps"               : [[
+                "identifier" : "conclusion",
+                "title"      : "Title 123",
+                "text"       : "Text 123",
+                "detailText" : "Detail Text 123"
+                ]
+            ]
+        ]
+        
+        let result = inputTask.createORKTask()
+        XCTAssertNotNil(result)
+        XCTAssertEqual(result?.identifier, "Trail Making")
+        
+        guard let task = result as? ORKOrderedTask else {
+            XCTAssert(false, "\(result) not of expect class")
+            return
+        }
+        
+        let expectedCount = 6
+        XCTAssertEqual(task.steps.count, expectedCount, "\(task.steps)")
+        guard task.steps.count == expectedCount else { return }
+        
+        // Step 1 - Overview
+        guard let instructionStep = task.steps.first as? ORKInstructionStep else {
+            XCTAssert(false, "\(task.steps.first) not of expect class")
+            return
+        }
+        XCTAssertEqual(instructionStep.identifier, "instruction")
+        XCTAssertEqual(instructionStep.text, "intended Use Description Text")
+        
+        // Step 2 - Instruction
+        guard let instruction1Step = task.steps[1] as? ORKInstructionStep else {
+            XCTAssert(false, "\(task.steps[1]) not of expect class")
+            return
+        }
+        XCTAssertEqual(instruction1Step.identifier, "instruction1")
+        
+        // Step 3 - Instruction
+        guard let instruction2Step = task.steps[2] as? ORKInstructionStep else {
+            XCTAssert(false, "\(task.steps[2]) not of expect class")
+            return
+        }
+        XCTAssertEqual(instruction2Step.identifier, "instruction2")
+        XCTAssertEqual(instruction2Step.text, "trail making instruction")
+
+        
+        // Countdown
+        guard let countdownStep = task.steps[3] as? ORKCountdownStep else {
+            XCTAssert(false, "\(task.steps[3]) not of expect class")
+            return
+        }
+        XCTAssertEqual(countdownStep.identifier, "countdown")
+        
+        // Countdown
+        guard let trailmakingStep = task.steps[4] as? ORKTrailmakingStep else {
+            XCTAssert(false, "\(task.steps[4]) not of expect class")
+            return
+        }
+        XCTAssertEqual(trailmakingStep.identifier, "trailmaking")
+        XCTAssertEqual(trailmakingStep.trailType, ORKTrailMakingTypeIdentifier.A)
+        
+        // Completion
+        guard let completionStep = task.steps.last as? ORKCompletionStep else {
+            XCTAssert(false, "\(task.steps.last) not of expect class")
+            return
+        }
+        XCTAssertEqual(completionStep.identifier, "conclusion")
+        XCTAssertEqual(completionStep.title, "Title 123")
+        XCTAssertEqual(completionStep.text, "Text 123")
+        XCTAssertEqual(completionStep.detailText, "Detail Text 123")
+    }
+    
     func testMemoryTask() {
         
         let inputTask: NSDictionary = [


### PR DESCRIPTION
This is an example for the steps required to add a task (that has been defined in ResearchKit) to the BridgeAppSDK. This includes:

1. Update the submodule to point to Sage's current default branch of https://github.com/Sage-bionetworks/ResearchKit with your changes built in. (Reference pull request to that branch.

Sage PR: https://github.com/Sage-Bionetworks/ResearchKit/pull/40
ResearchKit PR: https://github.com/ResearchKit/ResearchKit/pull/880

2. Add a `taskType` to the `SBAActiveTask` including a method for creating the task.
3. Add an override to `ORKResults+ResultsExtension` to convert the ORKResult for the task to a schema that Bridge can translate into a Synapse Table.
4. Add a unit test for the task to `SBAActiveTaskTests`
5. Add the task to the sample app BridgeInfo.plist

From within the [Bridge Researcher UI](https://research.sagebridge.org), you will need to add the following:

1. Task Identifier - This maps to the `taskMapping` in the BridgeInfo.plist and is used to map to the `SBBTaskReference` included with a scheduled activity.

<img width="1227" alt="screenshot 2016-12-15 10 27 49" src="https://cloud.githubusercontent.com/assets/5649217/21238861/7f8342ba-c2b9-11e6-8b07-c30e38c849dd.png">

2. Schema - This maps to the `schemaMapping` in the BridgeInfo.plist and the schema you have defined in your override within `ORKResult+ResultExtensions`. Note: the "trailmaking.json" suffix defined for this example is determined as "<result.identifier>.json"

<img width="1205" alt="screenshot 2016-12-15 10 15 17" src="https://cloud.githubusercontent.com/assets/5649217/21239001/fc4c3cc0-c2b9-11e6-8f51-b80dbc1eb578.png">

3. Schedule - Using the scheduler, you can then schedule the tasks.

<img width="1221" alt="screenshot 2016-12-15 10 27 32" src="https://cloud.githubusercontent.com/assets/5649217/21238986/f1a0a69e-c2b9-11e6-89cb-f76152c5e68c.png">



