### PR TITLE
BRIDGE-1637 Support multiple skip-to identifiers for SBBSurveyRules 

### DIFF
--- a/BridgeAppSDK.xcodeproj/project.pbxproj
+++ b/BridgeAppSDK.xcodeproj/project.pbxproj
@@ -96,6 +96,7 @@
 		FF3A354E1CBDAFE600F44E6E /* UIColor+Utilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF3A354D1CBDAFE600F44E6E /* UIColor+Utilities.swift */; };
 		FF3A359D1CBEB2D400F44E6E /* SBASharedInfoController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF3A359C1CBEB2D400F44E6E /* SBASharedInfoController.swift */; };
 		FF3B16291E0CD47C0037D1D0 /* SBADefines.h in Headers */ = {isa = PBXBuildFile; fileRef = FF3B16111E0CD44B0037D1D0 /* SBADefines.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		FF3B16301E1314A30037D1D0 /* SBANavigationQuestionStep.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF3B162F1E1314A30037D1D0 /* SBANavigationQuestionStep.swift */; };
 		FF3E30381D5A7A2E00347165 /* SBABridgeTask+SBBSurveyReference.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF3E30371D5A7A2E00347165 /* SBABridgeTask+SBBSurveyReference.swift */; };
 		FF3E30551D5A806C00347165 /* SBASurveyTask.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF3E30541D5A806C00347165 /* SBASurveyTask.swift */; };
 		FF3E30831D5CE85D00347165 /* SBAActivityArchiveTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF3E30821D5CE85D00347165 /* SBAActivityArchiveTests.swift */; };
@@ -520,6 +521,7 @@
 		FF3A354D1CBDAFE600F44E6E /* UIColor+Utilities.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIColor+Utilities.swift"; sourceTree = "<group>"; };
 		FF3A359C1CBEB2D400F44E6E /* SBASharedInfoController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SBASharedInfoController.swift; sourceTree = "<group>"; };
 		FF3B16111E0CD44B0037D1D0 /* SBADefines.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SBADefines.h; sourceTree = "<group>"; };
+		FF3B162F1E1314A30037D1D0 /* SBANavigationQuestionStep.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SBANavigationQuestionStep.swift; sourceTree = "<group>"; };
 		FF3E30371D5A7A2E00347165 /* SBABridgeTask+SBBSurveyReference.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "SBABridgeTask+SBBSurveyReference.swift"; sourceTree = "<group>"; };
 		FF3E30541D5A806C00347165 /* SBASurveyTask.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SBASurveyTask.swift; sourceTree = "<group>"; };
 		FF3E30821D5CE85D00347165 /* SBAActivityArchiveTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SBAActivityArchiveTests.swift; sourceTree = "<group>"; };
@@ -1023,6 +1025,7 @@
 				FB6BA0961C7CDB2600C9903F /* SBASubtaskStep.swift */,
 				FBE551681C6D9CBC00C9E1AA /* SBASurveyNavigationStep.swift */,
 				FF36DC6E1DB68F230034C85D /* SBAToggleFormStep.swift */,
+				FF3B162F1E1314A30037D1D0 /* SBANavigationQuestionStep.swift */,
 			);
 			name = Step;
 			sourceTree = "<group>";
@@ -1998,6 +2001,7 @@
 				FF21DE701DDBDA4A00C0B181 /* SBADemographicDataArchive.swift in Sources */,
 				FFBB57261CACEAA00041F120 /* SBAActiveTask+Dictionary.swift in Sources */,
 				FF1F8D351CA9B9650098FAC5 /* SBAUserWrapper.swift in Sources */,
+				FF3B16301E1314A30037D1D0 /* SBANavigationQuestionStep.swift in Sources */,
 				6099B9A01E008B6400902297 /* SBAAppInfoDelegate.swift in Sources */,
 				FF9D4C3F1CA1FC28001C293C /* SBAAppDelegate.swift in Sources */,
 				FBE1A9651CAB322700F1F584 /* SBAActiveTask.swift in Sources */,

--- a/BridgeAppSDK/SBANavigationQuestionStep.swift
+++ b/BridgeAppSDK/SBANavigationQuestionStep.swift
@@ -1,0 +1,124 @@
+//
+//  SBANavigationQuestionStep.swift
+//  BridgeAppSDK
+//
+//  Copyright © 2016 Sage Bionetworks. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification,
+// are permitted provided that the following conditions are met:
+//
+// 1.  Redistributions of source code must retain the above copyright notice, this
+// list of conditions and the following disclaimer.
+//
+// 2.  Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation and/or
+// other materials provided with the distribution.
+//
+// 3.  Neither the name of the copyright holder(s) nor the names of any contributors
+// may be used to endorse or promote products derived from this software without
+// specific prior written permission. No license is granted to the trademarks of
+// the copyright holders even if such marks are included in this software.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+
+import ResearchKit
+
+public class SBASurveyRuleItem: SBADataObject, SBASurveyRule {
+    
+    public var skipIdentifier: String? {
+        return self.identifier
+    }
+    
+    public dynamic var rulePredicate: NSPredicate?
+    
+    override open func dictionaryRepresentationKeys() -> [String] {
+        return super.dictionaryRepresentationKeys().appending(#keyPath(rulePredicate))
+    }
+    
+    public init(skipIdentifier: String, rulePredicate: NSPredicate) {
+        super.init(identifier: skipIdentifier)
+        self.rulePredicate = rulePredicate
+    }
+    
+    public required init(coder aDecoder: NSCoder) {
+        super.init(coder: aDecoder)
+    }
+    
+    public required init(dictionaryRepresentation dictionary: [AnyHashable : Any]) {
+        super.init(dictionaryRepresentation: dictionary)
+    }
+}
+
+public class SBANavigationQuestionStep: ORKQuestionStep, SBANavigationRule {
+
+    public var rules: [SBASurveyRule]?
+    
+    public func nextStepIdentifier(with result: ORKTaskResult, and additionalTaskResults: [ORKTaskResult]?) -> String? {
+        guard let rules = self.rules,
+            let stepResult = result.result(forIdentifier: self.identifier) as? ORKStepResult,
+            let questionResult = stepResult.result(forIdentifier: self.identifier)
+            else {
+                return nil
+        }
+        for rule in rules {
+            if let predicate = rule.rulePredicate, predicate.evaluate(with: questionResult) {
+                return rule.skipIdentifier
+            }
+        }
+        return nil
+    }
+
+    override public required init(identifier: String) {
+        super.init(identifier: identifier)
+    }
+    
+    init(inputItem: SBAFormStepSurveyItem, factory: SBASurveyFactory? = nil) {
+        super.init(identifier: inputItem.identifier)
+        inputItem.mapStepValues(with: self)
+        let subtype = inputItem.surveyItemType.formSubtype()
+        self.answerFormat = factory?.createAnswerFormat(inputItem, subtype: subtype) ?? inputItem.createAnswerFormat(subtype)
+        self.rules = inputItem.rules
+    }
+    
+    // MARK: NSCopying
+    
+    override public func copy(with zone: NSZone? = nil) -> Any {
+        let copy = super.copy(with: zone) as! SBANavigationQuestionStep
+        copy.rules = self.rules
+        return copy
+    }
+    
+    // MARK: NSSecureCoding
+    
+    required public init(coder aDecoder: NSCoder) {
+        super.init(coder: aDecoder);
+        self.rules = aDecoder.decodeObject(forKey: "rules") as? [SBASurveyRule]
+    }
+    
+    override public func encode(with aCoder: NSCoder){
+        super.encode(with: aCoder)
+        aCoder.encode(self.rules, forKey: "rules")
+    }
+    
+    // MARK: Equality
+    
+    override public func isEqual(_ object: Any?) -> Bool {
+        guard let castObject = object as? SBANavigationQuestionStep else { return false }
+        return super.isEqual(object) &&
+            SBAObjectEquality(castObject.rules, self.rules)
+    }
+    
+    override public var hash: Int {
+        return super.hash ^ SBAObjectHash(self.rules)
+    }
+}

--- a/BridgeAppSDK/SBASurveyItem+Dictionary.swift
+++ b/BridgeAppSDK/SBASurveyItem+Dictionary.swift
@@ -124,7 +124,7 @@ extension NSDictionary: SBAInstructionStepSurveyItem {
     }
 }
 
-extension NSDictionary: SBAFormStepSurveyItem {
+extension NSDictionary: SBAFormStepSurveyItem, SBASurveyRule {
     
     public var placeholderText: String? {
         return self["placeholder"] as? String
@@ -141,6 +141,11 @@ extension NSDictionary: SBAFormStepSurveyItem {
     
     public var range: AnyObject? {
         return nil 
+    }
+    
+    public var rules: [SBASurveyRule]? {
+        guard self.rulePredicate != nil || self.skipIdentifier != nil else { return nil }
+        return [self]
     }
     
     public var skipIdentifier: String? {

--- a/BridgeAppSDK/SBASurveyItem.swift
+++ b/BridgeAppSDK/SBASurveyItem.swift
@@ -52,15 +52,19 @@ public protocol SBAActiveStepSurveyItem: SBASurveyItem {
     var stepFinishedSpokenInstruction: String? { get }
 }
 
+public protocol SBASurveyRule : NSSecureCoding {
+    var skipIdentifier: String? { get }
+    var rulePredicate: NSPredicate? { get }
+}
+
 public protocol SBAFormStepSurveyItem: SBASurveyItem {
     var questionStyle: Bool { get }
     var placeholderText: String? { get }
     var optional: Bool { get }
     var items: [Any]? { get }
     var range: AnyObject? { get }
-    var skipIdentifier: String? { get }
     var skipIfPassed: Bool { get }
-    var rulePredicate: NSPredicate? { get }
+    var rules: [SBASurveyRule]? { get }
 }
 
 public protocol SBAInstructionStepSurveyItem: SBASurveyItem {


### PR DESCRIPTION
Note: This is only applicable to SBBSurveyRules. Surveys built using a dictionary still only support a single identifier.