### PR TITLE
Revert to full scheduled activity guid in archive

### DIFF
--- a/BridgeAppSDK/DataArchiving/SBAActivityArchive.swift
+++ b/BridgeAppSDK/DataArchiving/SBAActivityArchive.swift
@@ -38,6 +38,8 @@ private let kSurveyGuidKey                    = "surveyGuid"
 private let kSchemaRevisionKey                = "schemaRevision"
 private let kTaskIdentifierKey                = "taskIdentifier"
 private let kScheduledActivityGuidKey         = "scheduledActivityGuid"
+private let kScheduleIdentifierKey            = "scheduleIdentifier"
+private let kScheduledOnKey                   = "scheduledOn"
 private let kScheduledActivityLabelKey        = "activityLabel"
 private let kTaskRunUUIDKey                   = "taskRunUUID"
 private let kStartDate                        = "startDate"
@@ -57,8 +59,10 @@ open class SBAActivityArchive: SBADataArchive, SBASharedInfoController {
         super.init(reference: result.schemaIdentifier, jsonValidationMapping: jsonValidationMapping)
         
         // set up the activity metadata
-        // -- always set scheduledActivityGuid, activityLabel, and taskRunUUID
-        self.metadata[kScheduledActivityGuidKey] = result.schedule.scheduleIdentifier as AnyObject?
+        // -- always set scheduledActivityGuid, scheduleIdentifier, scheduledOn, activityLabel, and taskRunUUID
+        self.metadata[kScheduledActivityGuidKey] = result.schedule.guid as AnyObject?
+        self.metadata[kScheduleIdentifierKey] = result.schedule.scheduleIdentifier as AnyObject?
+        self.metadata[kScheduledOnKey] = (result.schedule.scheduledOn as NSDate).iso8601String() as AnyObject?
         self.metadata[kScheduledActivityLabelKey] = result.schedule.activity.label as AnyObject?
         self.metadata[kTaskRunUUIDKey] = result.taskRunUUID.uuidString as AnyObject?
         


### PR DESCRIPTION
Lilly was using both parts, and it’s possible (at least in Lilly, not necessarily in general) but tricky to infer the originally scheduled date/time in Synapse otherwise. Also the “scheduleIdentifier” is unique to the schedule but not to the particular scheduledActivity instance, so using the scheduledActivityGuid key name for the schedule identifier is misleading.

That being said, it’s also useful (probably usually more so) to have the scheduleIdentifier and scheduledOn available separately with no parsing to split them out during analysis, so I’ve added two new keys to the metadata for those.