### PR TITLE
Bridge 1655 participant caching

### DIFF
--- a/BridgeAppSDK/SBAUser.swift
+++ b/BridgeAppSDK/SBAUser.swift
@@ -450,13 +450,6 @@ extension SBAUser : SBBAuthManagerDelegateProtocol {
         return token
     }
     
-    public func authManager(_ authManager: SBBAuthManagerProtocol?, didGetSessionToken sessionToken: String?) {
-        #if DEBUG
-            print("setting Session Token: \(sessionToken)")
-        #endif
-        self.sessionToken = sessionToken
-    }
-    
     public func authManager(_ authManager: SBBAuthManagerProtocol?, didGetSessionToken sessionToken: String?, forEmail email: String?, andPassword password: String?) {
         #if DEBUG
             print("setting Session Token: \(sessionToken)")

--- a/BridgeAppSDK/SBAUserWrapper+Bridge.swift
+++ b/BridgeAppSDK/SBAUserWrapper+Bridge.swift
@@ -232,7 +232,7 @@ public extension SBAUserWrapper {
      @param completion  Completion handler
      */
     public func verifyRegistration(_ completion: ((Error?) -> Void)?) {
-        guard let username = self.email?(forAuthManager: nil), let password = self.password(forAuthManager: nil) else {
+        guard let username = self.email(forAuthManager: nil), let password = self.password(forAuthManager: nil) else {
             assertionFailure("Attempting to login without a stored username and password")
             return
         }
@@ -248,7 +248,7 @@ public extension SBAUserWrapper {
      @param completion  Completion handler
      */
     func resendVerificationEmail(_ completion: ((Error?) -> Void)?) {
-        guard let email = self.email?(forAuthManager: nil) else {
+        guard let email = self.email(forAuthManager: nil) else {
             assertionFailure("Attempting to resend verification email without a stored email")
             return
         }

--- a/BridgeAppSDK/SBAUserWrapper+Bridge.swift
+++ b/BridgeAppSDK/SBAUserWrapper+Bridge.swift
@@ -137,7 +137,7 @@ public extension SBAUserWrapper {
      @param completion  Completion handler
      */
     public func changeUserEmailAddress(_ email: String, completion: ((Error?) -> Void)?) {
-        guard let password = self.password?(forAuthManager: nil) else {
+        guard let password = self.password(forAuthManager: nil) else {
             assertionFailure("Attempting to change email without a stored password")
             return
         }
@@ -232,7 +232,7 @@ public extension SBAUserWrapper {
      @param completion  Completion handler
      */
     public func verifyRegistration(_ completion: ((Error?) -> Void)?) {
-        guard let username = self.email?(forAuthManager: nil), let password = self.password?(forAuthManager: nil) else {
+        guard let username = self.email?(forAuthManager: nil), let password = self.password(forAuthManager: nil) else {
             assertionFailure("Attempting to login without a stored username and password")
             return
         }


### PR DESCRIPTION
Requires https://github.com/Sage-Bionetworks/Bridge-iOS-SDK/pull/110

Remove obsolete/deprecated delegate method, support password(forAuthManager:) being required now, update to BridgeSDK with fix for Bridge 1655