### PR TITLE
Add methods to set the navigation bar tint color appearance

### DIFF
--- a/BridgeAppSDK/SBAAppDelegate.swift
+++ b/BridgeAppSDK/SBAAppDelegate.swift
@@ -95,9 +95,15 @@ public let SBAMainStoryboardName = "Main"
 
         self.initializeBridgeServerConnection()
         
-        // Set the window tint color if applicable
-        if let tintColor = UIColor.primaryTintColor() {
+        // Set the tint colors if applicable
+        if let tintColor = UIColor.primaryTintColor {
             self.window?.tintColor = tintColor
+        }
+        if let tintColor = UIColor.taskNavigationBarTintColor {
+            UINavigationBar.appearance(whenContainedInInstancesOf: [ORKTaskViewController.self]).barTintColor = tintColor
+        }
+        if let tintColor = UIColor.taskNavigationButtonTintColor {
+            UINavigationBar.appearance(whenContainedInInstancesOf: [ORKTaskViewController.self]).tintColor = tintColor
         }
         
         // Replace the launch root view controller with an SBARootViewController

--- a/BridgeAppSDKSample/ColorInfo.plist
+++ b/BridgeAppSDKSample/ColorInfo.plist
@@ -4,7 +4,13 @@
 <dict>
 	<key>greenTintColor</key>
 	<string>#44D24E</string>
+	<key>blueTintColor</key>
+	<string>#3B8CE3</string>
 	<key>primaryTintColor</key>
 	<string>#8E35EF</string>
+	<key>taskNavigationBarTintColor</key>
+	<string>#A868ED</string>
+	<key>taskNavigationButtonTintColor</key>
+	<string>#F7F2F2</string>
 </dict>
 </plist>


### PR DESCRIPTION
Requires: https://github.com/Sage-Bionetworks/ResearchUXFactory-iOS/pull/6

Added nav bar tint color to the default methods. This allows for setting the task navigation bar to some color other than white.  Since the way ResearchKit wants you to do this is obscure, I thought it would be helpful to add as an example.