### PR TITLE
[BRIDGE-1680] Fix timestamps on files in info.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 UserInterfaceState.xcuserstate
 BridgeAppSDK.xcodeproj/xcuserdata/*.xcuserdatad
+.DS_Store

--- a/BridgeAppSDK.xcodeproj/project.pbxproj
+++ b/BridgeAppSDK.xcodeproj/project.pbxproj
@@ -1921,10 +1921,6 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 12;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PROJECT_DIR)/CMSSupport/openssl/build/Debug-iphoneos",
-				);
 				INFOPLIST_FILE = BridgeAppSDK/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
@@ -1951,10 +1947,6 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 12;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PROJECT_DIR)/CMSSupport/openssl/build/Debug-iphoneos",
-				);
 				INFOPLIST_FILE = BridgeAppSDK/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;

--- a/BridgeAppSDK/BridgeAppSDK.h
+++ b/BridgeAppSDK/BridgeAppSDK.h
@@ -44,5 +44,6 @@ FOUNDATION_EXPORT const unsigned char BridgeAppSDKVersionString[];
 #import <BridgeAppSDK/SBADefines.h>
 #import <BridgeAppSDK/SBADemographicDataObjectType.h>
 #import <BridgeAppSDK/SBALog.h>
+#import <BridgeAppSDK/SBADataArchive.h>
 #import <BridgeAppSDK/SBANewsFeedItem.h>
 #import <BridgeAppSDK/SBANewsFeedManager.h>

--- a/BridgeAppSDK/DataArchiving/SBAActivityArchive.swift
+++ b/BridgeAppSDK/DataArchiving/SBAActivityArchive.swift
@@ -122,7 +122,7 @@ open class SBAActivityArchive: SBBDataArchive, SBASharedInfoController {
         // don't insert the metadata if the archive is otherwise empty
         let builtArchive = !isEmpty()
         if builtArchive {
-            insertDictionary(intoArchive: self.metadata, filename: kMetadataFilename)
+            insertDictionary(intoArchive: self.metadata, filename: kMetadataFilename, createdOn: activityResult.startDate)
         }
 
         return builtArchive
@@ -141,9 +141,9 @@ open class SBAActivityArchive: SBBDataArchive, SBASharedInfoController {
         if let urlResult = archiveableResult.result as? URL {
             self.insertURL(intoArchive: urlResult, fileName: archiveableResult.filename)
         } else if let dictResult = archiveableResult.result as? [AnyHashable: Any] {
-            self.insertDictionary(intoArchive: dictResult, filename: archiveableResult.filename)
+            self.insertDictionary(intoArchive: dictResult, filename: archiveableResult.filename, createdOn: result.startDate)
         } else if let dataResult = archiveableResult.result as? NSData {
-            self.insertData(intoArchive: dataResult as Data, filename: archiveableResult.filename)
+            self.insertData(intoArchive: dataResult as Data, filename: archiveableResult.filename, createdOn: result.startDate)
         } else {
             let className = NSStringFromClass(archiveableResult.result.classForCoder)
             assertionFailure("Unsupported archiveable result type: \(className)")

--- a/BridgeAppSDK/DataArchiving/SBADemographicDataArchive.swift
+++ b/BridgeAppSDK/DataArchiving/SBADemographicDataArchive.swift
@@ -78,6 +78,6 @@ public class SBADemographicDataArchive: SBBDataArchive, SBASharedInfoController 
         }
         
         // Add to archive
-        insertDictionary(intoArchive: demographics, filename: kFileIdentifierKey)
+        insertDictionary(intoArchive: demographics, filename: kFileIdentifierKey, createdOn: Date())
     }
 }


### PR DESCRIPTION
also fix some build warnings introduced when moving archiving to BridgeSDK

Requires https://github.com/Sage-Bionetworks/Bridge-iOS-SDK/pull/116