### PR TITLE
Bridge 1701

### DIFF
--- a/BridgeAppSDK/SBAConsentDocumentFactory.swift
+++ b/BridgeAppSDK/SBAConsentDocumentFactory.swift
@@ -106,9 +106,11 @@ open class SBAConsentDocumentFactory: SBASurveyFactory {
                 let signature = self.consentDocument.signatures?.first
                 signature?.requiresName = consentReview.requiresSignature
                 signature?.requiresSignatureImage = consentReview.requiresSignature
-                return ORKConsentReviewStep(identifier: inputItem.identifier,
-                                            signature: signature,
-                                            in: self.consentDocument)
+                let reviewStep = ORKConsentReviewStep(identifier: inputItem.identifier,
+                                                                        signature: signature,
+                                                                        in: self.consentDocument)
+                reviewStep.reasonForConsent = Localization.localizedString("SBA_CONSENT_SIGNATURE_CONTENT")
+                return reviewStep
             }
             else {
                 let review = inputItem as! SBAFormStepSurveyItem


### PR DESCRIPTION
Add the reason for consent to review step to populate alert, ResearchKit doesn't appear to be pulling it from the consent document and instead just has a property on the step