### PR TITLE
Modify the profile manager and SBAUser to have one-way pointers

### DIFF
--- a/BridgeAppSDK.xcodeproj/project.pbxproj
+++ b/BridgeAppSDK.xcodeproj/project.pbxproj
@@ -124,6 +124,7 @@
 		FF78CF6B1D00C1B7002C456D /* consent_full.html in Resources */ = {isa = PBXBuildFile; fileRef = FF78CF6A1D00C1B7002C456D /* consent_full.html */; };
 		FF78CF891D00F3DB002C456D /* EligibilityRequirements.json in Resources */ = {isa = PBXBuildFile; fileRef = FF78CF881D00F3DB002C456D /* EligibilityRequirements.json */; };
 		FF78CF9F1D0144BF002C456D /* SBARegistrationStep.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF78CF9E1D0144BF002C456D /* SBARegistrationStep.swift */; };
+		FF7C29E01ECBA268009FDA44 /* MockKeychainWrapper.m in Sources */ = {isa = PBXBuildFile; fileRef = FF7C29DF1ECBA268009FDA44 /* MockKeychainWrapper.m */; };
 		FF812A251DDCEC6700A61655 /* SBAChangeEmailStep.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF812A241DDCEC6700A61655 /* SBAChangeEmailStep.swift */; };
 		FF84AB661D90A7D900ABD54C /* HealthKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FF84AB651D90A7D900ABD54C /* HealthKit.framework */; };
 		FF8630431E709C9E0077AC57 /* Interface.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = FF8630411E709C9E0077AC57 /* Interface.storyboard */; };
@@ -529,6 +530,8 @@
 		FF78CF6A1D00C1B7002C456D /* consent_full.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = consent_full.html; sourceTree = "<group>"; };
 		FF78CF881D00F3DB002C456D /* EligibilityRequirements.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = EligibilityRequirements.json; sourceTree = "<group>"; };
 		FF78CF9E1D0144BF002C456D /* SBARegistrationStep.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = SBARegistrationStep.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
+		FF7C29DE1ECBA268009FDA44 /* MockKeychainWrapper.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MockKeychainWrapper.h; sourceTree = "<group>"; };
+		FF7C29DF1ECBA268009FDA44 /* MockKeychainWrapper.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MockKeychainWrapper.m; sourceTree = "<group>"; };
 		FF812A241DDCEC6700A61655 /* SBAChangeEmailStep.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SBAChangeEmailStep.swift; sourceTree = "<group>"; };
 		FF84AB651D90A7D900ABD54C /* HealthKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = HealthKit.framework; path = System/Library/Frameworks/HealthKit.framework; sourceTree = SDKROOT; };
 		FF86303F1E709C9D0077AC57 /* Sage Cardio Challenge.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Sage Cardio Challenge.app"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -906,6 +909,8 @@
 				FF8997591D0B3B9800B26051 /* MockAppInfoDelegate.m */,
 				FF8997771D0B585600B26051 /* MockBridgeInfo.h */,
 				FF8997781D0B585600B26051 /* MockBridgeInfo.m */,
+				FF7C29DE1ECBA268009FDA44 /* MockKeychainWrapper.h */,
+				FF7C29DF1ECBA268009FDA44 /* MockKeychainWrapper.m */,
 				FF8997911D0B589500B26051 /* MockUser.h */,
 				FF8997921D0B589500B26051 /* MockUser.m */,
 			);
@@ -1749,6 +1754,7 @@
 				FF3075551DF6209800F2B3EA /* SBAUserProfileControllerTests.swift in Sources */,
 				FF8997931D0B589500B26051 /* MockUser.m in Sources */,
 				FFCE310D1EC1273C0086DCAA /* SBABridgeManagerTests.swift in Sources */,
+				FF7C29E01ECBA268009FDA44 /* MockKeychainWrapper.m in Sources */,
 				FB8439201C7315030086E961 /* SBASurveyFactoryTests.swift in Sources */,
 				FFDECDFD1D077C2000434001 /* SBAConsentTests.swift in Sources */,
 				FF3E30831D5CE85D00347165 /* SBAActivityArchiveTests.swift in Sources */,

--- a/BridgeAppSDK/SBABridgeInfo.swift
+++ b/BridgeAppSDK/SBABridgeInfo.swift
@@ -93,6 +93,13 @@ public protocol SBABridgeInfo: SBASharedAppInfo, SBBBridgeInfoProtocol {
     var disableTestUserCheck: Bool { get }
 }
 
+extension SBABridgeInfo {
+    
+    public func createKeychainWrapper() -> SBAKeychainWrapper {
+        return SBAKeychainWrapper(service: keychainService, accessGroup: keychainAccessGroup)
+    }
+}
+
 /**
  This is an implementation of the SBABridgeInfo protocol that uses a dictionary to 
  define the values required by the BridgeInfo protocol.

--- a/BridgeAppSDK/SBABridgeManager.h
+++ b/BridgeAppSDK/SBABridgeManager.h
@@ -56,6 +56,12 @@ typedef void (^SBABridgeManagerCompletionBlock)(id _Nullable responseObject, NSE
  */
 @interface SBABridgeManager : NSObject
 
+/**
+ Ensure that the resource bundle for BridgeAppSDK is added to the resources *before* calling into the 
+ class map or resource finder.
+ */
++ (void)addResourceBundleIfNeeded;
+
 /*!
   Set up the Bridge SDK for the given study and pointing at the production environment.
  Usually you would call this at the beginning of your AppDelegate's application:didFinishLaunchingWithOptions: method.

--- a/BridgeAppSDK/SBAProfileItem.h
+++ b/BridgeAppSDK/SBAProfileItem.h
@@ -34,6 +34,8 @@
 #import <Foundation/Foundation.h>
 #import "SBADefines.h"
 
+NS_ASSUME_NONNULL_BEGIN
+
 typedef NSString * SBAProfileTypeIdentifier NS_EXTENSIBLE_STRING_ENUM;
 
 ENUM_EXTERN SBAProfileTypeIdentifier const SBAProfileTypeIdentifierString;
@@ -43,7 +45,27 @@ ENUM_EXTERN SBAProfileTypeIdentifier const SBAProfileTypeIdentifierDate;
 ENUM_EXTERN SBAProfileTypeIdentifier const SBAProfileTypeIdentifierHKBiologicalSex;
 ENUM_EXTERN SBAProfileTypeIdentifier const SBAProfileTypeIdentifierHKQuantity;
 
-typedef NSString *SBAUserProtocolExtension NS_EXTENSIBLE_STRING_ENUM;
+typedef NSString *SBAProfileSourceKey NS_EXTENSIBLE_STRING_ENUM;
 
-ENUM_EXTERN SBAUserProtocolExtension const SBAUserProtocolExtensionGivenName;
-ENUM_EXTERN SBAUserProtocolExtension const SBAUserProtocolExtensionFullName;
+ENUM_EXTERN SBAProfileSourceKey const SBAProfileSourceKeyGivenName;
+ENUM_EXTERN SBAProfileSourceKey const SBAProfileSourceKeyFamilyName;
+ENUM_EXTERN SBAProfileSourceKey const SBAProfileSourceKeyFullName;
+ENUM_EXTERN SBAProfileSourceKey const SBAProfileSourceKeyPreferredName;
+
+
+/**
+ Implementation should manage adding and removing objects from the keychain.
+ */
+@protocol SBAKeychainWrapperProtocol <NSObject>
+
+- (BOOL)setObject:(id<NSSecureCoding>)object forKey:(NSString *)key error:(NSError * _Nullable *)error;
+
+- (id<NSSecureCoding>)objectForKey:(NSString *)key error:(NSError * _Nullable *)error;
+
+- (BOOL)removeObjectForKey:(NSString *)key error:(NSError * _Nullable *)error;
+
+- (BOOL)resetKeychainWithError:(NSError * _Nullable *)error;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/BridgeAppSDK/SBAProfileItem.swift
+++ b/BridgeAppSDK/SBAProfileItem.swift
@@ -286,18 +286,18 @@ open class SBAKeychainProfileItem: SBAProfileItemBase {
                     try keychain.removeObject(forKey: sourceKey)
                 } else {
                     if !self.commonCheckTypeCompatible(newValue: newValue) {
-                        assert(false, "Error setting \(sourceKey): \(String(describing: newValue)) not compatible with specified type \(itemType.rawValue)")
+                        assertionFailure("Error setting \(sourceKey) (\(profileKey)): \(String(describing: newValue)) not compatible with specified type \(itemType.rawValue)")
                         return
                     }
                     guard let secureVal = secureCodingValue(of: newValue) else {
-                        assert(false, "Error setting \(sourceKey) in keychain: don't know how to convert \(String(describing: newValue))) to NSSecureCoding")
+                        assertionFailure("Error setting \(sourceKey) (\(profileKey)) in keychain: don't know how to convert \(String(describing: newValue))) to NSSecureCoding")
                         return
                     }
                     try keychain.setObject(secureVal, forKey: sourceKey)
                 }
             }
             catch let error {
-                assert(false, "Failed to set \(sourceKey): \(String(describing: error))")
+                assert(false, "Failed to set \(sourceKey) (\(profileKey)): \(String(describing: error))")
             }
         }
     }
@@ -395,11 +395,11 @@ open class SBAUserDefaultsProfileItem: SBAProfileItemBase {
                 defaults.removeObject(forKey: sourceKey)
             } else {
                 if !self.commonCheckTypeCompatible(newValue: newValue) {
-                    assert(false, "Error setting \(sourceKey): \(String(describing: newValue)) not compatible with specified type\(itemType.rawValue)")
+                    assertionFailure("Error setting \(sourceKey) (\(profileKey)): \(String(describing: newValue)) not compatible with specified type\(itemType.rawValue)")
                     return
                 }
                 guard let plistVal = pListValue(of: newValue) else {
-                    assert(false, "Error setting \(sourceKey) in user defaults: don't know how to convert \(String(describing: newValue)) to PlistValue")
+                    assertionFailure("Error setting \(sourceKey) (\(profileKey)) in user defaults: don't know how to convert \(String(describing: newValue)) to PlistValue")
                     return
                 }
                 defaults.set(plistVal, forKey: sourceKey)
@@ -436,7 +436,7 @@ open class SBAUserProfileItem: SBAKeychainProfileItem, SBANameDataSource {
             switch SBAProfileSourceKey(sourceKey) {
             case SBAProfileSourceKey.preferredName:
                 // For the preferred name, if not a separate value stored, then return the given name
-                return super.value ?? self.storedValue(forKey: SBAProfileSourceKey.givenName.rawValue)
+                return super.value ?? self.givenName
                 
             case SBAProfileSourceKey.fullName:
                 // For the full name, if this class is used the it is assumed that the full name is 

--- a/BridgeAppSDK/SBAProfileManager.swift
+++ b/BridgeAppSDK/SBAProfileManager.swift
@@ -94,6 +94,10 @@ public protocol SBAProfileManagerProtocol: NSObjectProtocol {
 
 
 open class SBAProfileManager: SBADataObject, SBAProfileManagerProtocol {
+    
+    // The default keychain and user defaults are created by the info manager
+    public static let keychain = SBAInfoManager.shared.createKeychainWrapper()
+    public static let userDefaults = SBAInfoManager.shared.userDefaults
 
     /**
      The shared instance of the profile manager. Loads from SBAProfileItemsJSONFilename, which
@@ -107,10 +111,12 @@ open class SBAProfileManager: SBADataObject, SBAProfileManagerProtocol {
      to the fully qualified class name without setting up any mappings.
      */
     public static let shared: SBAProfileManagerProtocol? = {
+        SBABridgeManager.addResourceBundleIfNeeded()
         guard let json = SBAResourceFinder.shared.json(forResource: SBAProfileItemsJSONFilename),
                 let sharedProfileManager = SBAClassTypeMap.shared.object(with:json, classType:SBAProfileManagerClassType) as? SBAProfileManagerProtocol
             else {
-                assertionFailure("Couldn't find the shared profile manager.")
+                // The SBAUser will default to the profile manager if available, but if not will fall-back
+                // to older methods for storing information.
                 return SBAProfileManager(dictionaryRepresentation: [:])
         }
         return sharedProfileManager

--- a/BridgeAppSDK/SBAUserWrapper.swift
+++ b/BridgeAppSDK/SBAUserWrapper.swift
@@ -58,14 +58,6 @@ public protocol SBAUserWrapper: SBAParticipantInfo, SBBAuthManagerDelegateProtoc
      * Password is stored in the keychain
      */
     var password: String? { get set }
-    
-    /**
-     * "Gender" can mean either biological sex or gender identity. Since older ResearchKit apps
-     * that used AppCore use this term to describe both properties, this is the term that 
-     * BridgeAppSDK will continue to use. It is up to a given app to determine what is the 
-     * appropriate language to use for this field. Stored in the keychain.
-     */
-    var gender: HKBiologicalSex { get set }
 
     /**
      * Subpopulation GUID is used for tracking by certain apps. Stored in the keychain.
@@ -76,11 +68,6 @@ public protocol SBAUserWrapper: SBAParticipantInfo, SBBAuthManagerDelegateProtoc
      * Consent signature should be stored in keychain.
      */
     var consentSignature: SBAConsentSignatureWrapper? { get set }
-
-    /**
-     * Profile Image is stored in the keychain
-     */
-    var profileImage: UIImage? { get set }
     
     /**
      * Data groups associated with this user.

--- a/BridgeAppSDKTests/BridgeAppSDKTests-Bridging-Header.h
+++ b/BridgeAppSDKTests/BridgeAppSDKTests-Bridging-Header.h
@@ -5,3 +5,4 @@
 #import "MockORKTask.h"
 #import "MockTrackedDataStore.h"
 #import "MockAppInfoDelegate.h"
+#import "MockKeychainWrapper.h"

--- a/BridgeAppSDKTests/MockObjects/MockKeychainWrapper.h
+++ b/BridgeAppSDKTests/MockObjects/MockKeychainWrapper.h
@@ -1,5 +1,5 @@
 //
-//  SBAProfileItem.m
+//  MockKeychainWrapper.h
 //  BridgeAppSDK
 //
 //  Copyright © 2017 Sage Bionetworks. All rights reserved.
@@ -31,16 +31,13 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //
 
-#import "SBAProfileItem.h"
+@import Foundation;
+@import BridgeAppSDK;
 
-SBAProfileTypeIdentifier const SBAProfileTypeIdentifierString = @"String";
-SBAProfileTypeIdentifier const SBAProfileTypeIdentifierNumber = @"Number";
-SBAProfileTypeIdentifier const SBAProfileTypeIdentifierBool = @"Bool";
-SBAProfileTypeIdentifier const SBAProfileTypeIdentifierDate = @"Date";
-SBAProfileTypeIdentifier const SBAProfileTypeIdentifierHKBiologicalSex = @"HKBiologicalSex";
-SBAProfileTypeIdentifier const SBAProfileTypeIdentifierHKQuantity = @"HKQuantity";
+@interface MockKeychainWrapper : NSObject <SBAKeychainWrapperProtocol>
 
-SBAProfileSourceKey const SBAProfileSourceKeyGivenName = @"givenName";
-SBAProfileSourceKey const SBAProfileSourceKeyFamilyName = @"familyName";
-SBAProfileSourceKey const SBAProfileSourceKeyFullName = @"fullName";
-SBAProfileSourceKey const SBAProfileSourceKeyPreferredName = @"preferredName";
+@property (nonatomic) NSMutableDictionary<NSString *, id> *keychain;
+@property (nonatomic) NSMutableDictionary<NSString *, NSError *> *errorMap;
+@property (nonatomic) BOOL reset_called;
+
+@end

--- a/BridgeAppSDKTests/MockObjects/MockKeychainWrapper.m
+++ b/BridgeAppSDKTests/MockObjects/MockKeychainWrapper.m
@@ -1,5 +1,5 @@
 //
-//  SBAProfileItem.m
+//  MockKeychainWrapper.m
 //  BridgeAppSDK
 //
 //  Copyright © 2017 Sage Bionetworks. All rights reserved.
@@ -31,16 +31,58 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //
 
-#import "SBAProfileItem.h"
+#import "MockKeychainWrapper.h"
 
-SBAProfileTypeIdentifier const SBAProfileTypeIdentifierString = @"String";
-SBAProfileTypeIdentifier const SBAProfileTypeIdentifierNumber = @"Number";
-SBAProfileTypeIdentifier const SBAProfileTypeIdentifierBool = @"Bool";
-SBAProfileTypeIdentifier const SBAProfileTypeIdentifierDate = @"Date";
-SBAProfileTypeIdentifier const SBAProfileTypeIdentifierHKBiologicalSex = @"HKBiologicalSex";
-SBAProfileTypeIdentifier const SBAProfileTypeIdentifierHKQuantity = @"HKQuantity";
+@implementation MockKeychainWrapper
 
-SBAProfileSourceKey const SBAProfileSourceKeyGivenName = @"givenName";
-SBAProfileSourceKey const SBAProfileSourceKeyFamilyName = @"familyName";
-SBAProfileSourceKey const SBAProfileSourceKeyFullName = @"fullName";
-SBAProfileSourceKey const SBAProfileSourceKeyPreferredName = @"preferredName";
+- (instancetype)init {
+    self = [super init];
+    if (self) {
+        _keychain = [NSMutableDictionary new];
+        _errorMap = [NSMutableDictionary new];
+    }
+    return self;
+}
+
+- (BOOL)setObject:(id<NSSecureCoding>)object forKey:(NSString *)key error:(NSError * _Nullable *)error {
+    NSError *err = _errorMap[key];
+    if (err) {
+        *error = err;
+        return false;
+    }
+    else {
+        _keychain[key] = object;
+        return true;
+    }
+}
+
+- (id<NSSecureCoding>)objectForKey:(NSString *)key error:(NSError * _Nullable *)error {
+    NSError *err = _errorMap[key];
+    if (err) {
+        *error = err;
+        return nil;
+    }
+    else {
+        return _keychain[key];
+    }
+}
+
+- (BOOL)removeObjectForKey:(NSString *)key error:(NSError * _Nullable *)error {
+    NSError *err = _errorMap[key];
+    if (err) {
+        *error = err;
+        return false;
+    }
+    else {
+        [_keychain removeObjectForKey:key];
+        return true;
+    }
+}
+
+- (BOOL)resetKeychainWithError:(NSError * _Nullable *)error {
+    self.reset_called = YES;
+    [_keychain removeAllObjects];
+    return true;
+}
+
+@end

--- a/BridgeAppSDKTests/SBAProfileManagerTests.swift
+++ b/BridgeAppSDKTests/SBAProfileManagerTests.swift
@@ -33,7 +33,7 @@ class SBAProfileManagerTests: ResourceTestCase {
             XCTFail("No ProfileManager instance")
             return
         }
-        XCTAssert(keys.count == 9, "expected 6 keys, got \(keys.count)")
+        XCTAssertEqual(keys.count, 9)
     }
     
     func testProfileItems() {
@@ -41,7 +41,7 @@ class SBAProfileManagerTests: ResourceTestCase {
             XCTFail("No ProfileManager instance")
             return
         }
-        XCTAssert(items.count == 9, "expected 6 items, got \(items.count)")
+        XCTAssertEqual(items.count, 9)
         
         let fullNameItem = items["fullName"]
         let externalIdItem = items["externalId"]

--- a/BridgeAppSDKTests/SBAProfileManagerTests.swift
+++ b/BridgeAppSDKTests/SBAProfileManagerTests.swift
@@ -11,13 +11,16 @@ import XCTest
 
 class SBAProfileManagerTests: ResourceTestCase {
     
-    var ProfileManager: SBAProfileManagerProtocol?
+    var profileManager: SBAProfileManagerProtocol!
     
     override func setUp() {
         super.setUp()
         // Put setup code here. This method is called before the invocation of each test method in the class.
-        guard let input = jsonForResource("ProfileDescription") as? [String: Any] else { return }
-        ProfileManager = SBAClassTypeMap.shared.object(with:input, classType:SBAProfileManagerClassType) as? SBAProfileManagerProtocol
+        guard let input = jsonForResource("ProfileDescription") as? [String: Any] else {
+            XCTFail("Cannot open ProfileManager file")
+            return
+        }
+        profileManager = SBAClassTypeMap.shared.object(with:input, classType:SBAProfileManagerClassType) as? SBAProfileManagerProtocol
     }
     
     override func tearDown() {
@@ -26,31 +29,33 @@ class SBAProfileManagerTests: ResourceTestCase {
     }
     
     func testProfileKeys() {
-        guard let keys = ProfileManager?.profileKeys() else {
+        guard let keys = profileManager?.profileKeys() else {
             XCTFail("No ProfileManager instance")
             return
         }
-        XCTAssert(keys.count == 6, "expected 6 keys, got \(keys.count)")
+        XCTAssert(keys.count == 9, "expected 6 keys, got \(keys.count)")
     }
     
     func testProfileItems() {
-        guard let items = ProfileManager?.profileItems() else {
+        guard let items = profileManager?.profileItems() else {
             XCTFail("No ProfileManager instance")
             return
         }
-        XCTAssert(items.count == 6, "expected 6 items, got \(items.count)")
+        XCTAssert(items.count == 9, "expected 6 items, got \(items.count)")
+        
         let fullNameItem = items["fullName"]
         let externalIdItem = items["externalId"]
         let genderItem = items["gender"]
         let birthDateItem = items["birthDate"]
         let favoriteColorItem = items["favoriteColor"]
         let numberOfSiblingsItem = items["numberOfSiblings"]
-        XCTAssert(fullNameItem != nil, "no item for profileKey fullName")
-        XCTAssert(externalIdItem != nil, "no item for profileKey externalId")
-        XCTAssert(genderItem != nil, "no item for profileKey gender")
-        XCTAssert(birthDateItem != nil, "no item for profileKey birthDate")
-        XCTAssert(favoriteColorItem != nil, "no item for profileKey favoriteColor")
-        XCTAssert(numberOfSiblingsItem != nil, "no item for profileKey numberOfSiblings")
+        
+        XCTAssertNotNil(fullNameItem, "no item for profileKey fullName")
+        XCTAssertNotNil(externalIdItem, "no item for profileKey externalId")
+        XCTAssertNotNil(genderItem, "no item for profileKey gender")
+        XCTAssertNotNil(birthDateItem, "no item for profileKey birthDate")
+        XCTAssertNotNil(favoriteColorItem, "no item for profileKey favoriteColor")
+        XCTAssertNotNil(numberOfSiblingsItem, "no item for profileKey numberOfSiblings")
         if fullNameItem != nil {
             XCTAssert(fullNameItem!.sourceKey == "fullName", "expected fullNameItem.sourceKey to be fullName, but it's \(fullNameItem!.sourceKey)")
             XCTAssert(fullNameItem!.demographicKey == fullNameItem!.profileKey, "expected fullNameItem.demographicKey to be \(fullNameItem!.profileKey), but it's \(fullNameItem!.demographicKey)")
@@ -96,11 +101,14 @@ class SBAProfileManagerTests: ResourceTestCase {
     }
     
     func testSetAndGetValueForProfileKey() {
-        guard let items = ProfileManager?.profileItems() else {
+        guard let items = profileManager?.profileItems() else {
             XCTFail("No ProfileManager instance")
             return
         }
         let fullNameItem = items["fullName"] as? BridgeAppSDK.SBAUserProfileItem
+        let givenNameItem = items["given"] as? BridgeAppSDK.SBAUserProfileItem
+        let familyNameItem = items["family"] as? BridgeAppSDK.SBAUserProfileItem
+        let preferredNameItem = items["preferredName"] as? BridgeAppSDK.SBAUserProfileItem
         let externalIdItem = items["externalId"] as? BridgeAppSDK.SBAUserProfileItem
         let genderItem = items["gender"] as? BridgeAppSDK.SBAKeychainProfileItem
         let birthDateItem = items["birthDate"] as? BridgeAppSDK.SBAKeychainProfileItem
@@ -112,95 +120,155 @@ class SBAProfileManagerTests: ResourceTestCase {
         XCTAssert(birthDateItem != nil, "no SBAKeychainProfileItem for profileKey birthDate")
         XCTAssert(favoriteColorItem != nil, "no SBAUserDefaultsProfileItem for profileKey favoriteColor")
         XCTAssert(numberOfSiblingsItem != nil, "no SBAUserDefaultsProfileItem for profileKey numberOfSiblings")
+        
+        // Use a mock for the keychain
+        let mockKeychain = MockKeychainWrapper()
+        fullNameItem?.keychain = mockKeychain
+        givenNameItem?.keychain = mockKeychain
+        familyNameItem?.keychain = mockKeychain
+        preferredNameItem?.keychain = mockKeychain
+        externalIdItem?.keychain = mockKeychain
+        genderItem?.keychain = mockKeychain
+        
+        // Use a uuid instance for the user defaults
+        let mockUserDefaults = UserDefaults(suiteName: UUID().uuidString)!
+        favoriteColorItem?.defaults = mockUserDefaults
+        numberOfSiblingsItem?.defaults = mockUserDefaults
+        
+        if givenNameItem != nil {
+            let testGiven = "Full"
+            do {
+                try profileManager!.setValue(testGiven, forProfileKey: givenNameItem!.profileKey);
+            }
+            catch {
+                XCTFail("Failed setting value for givenNameItem: unknown profile key \(givenNameItem!.profileKey)")
+            }
+            
+            let value = profileManager!.value(forProfileKey: givenNameItem!.profileKey) as? String
+            if value == nil {
+                XCTFail("Failed retrieving String value for givenNameItem")
+            } else {
+                XCTAssertEqual(testGiven, value!, "Expected value to be \(testGiven), but instead it's \(value!)")
+            }
+        }
+        
+        if familyNameItem != nil {
+            let testFamily = "Name"
+            do {
+                try profileManager!.setValue(testFamily, forProfileKey: familyNameItem!.profileKey);
+            }
+            catch {
+                XCTFail("Failed setting value for familyNameItem: unknown profile key \(familyNameItem!.profileKey)")
+            }
+            
+            let value = profileManager!.value(forProfileKey: familyNameItem!.profileKey) as? String
+            if value == nil {
+                XCTFail("Failed retrieving String value for familyNameItem")
+            } else {
+                XCTAssertEqual(testFamily, value!, "Expected value to be \(testFamily), but instead it's \(value!)")
+            }
+        }
+        
+        if preferredNameItem != nil {
+            let testName = "Full"
+            
+            let value = profileManager!.value(forProfileKey: preferredNameItem!.profileKey) as? String
+            if value == nil {
+                XCTFail("Failed retrieving String value for preferredNameItem")
+            } else {
+                XCTAssertEqual(testName, value!, "Expected value to be \(testName), but instead it's \(value!)")
+            }
+        }
+        
         if fullNameItem != nil {
             let testName = "Full Name"
             
-            // fullName is not a writeable property on SBAUser--it's a computed read-only property
-            // defined in a protocol extension
-            SBAUser.shared.name = "Full"
-            SBAUser.shared.familyName = "Name"
-            
-            let value = ProfileManager!.value(forProfileKey: fullNameItem!.profileKey) as? String
+            let value = profileManager!.value(forProfileKey: fullNameItem!.profileKey) as? String
             if value == nil {
                 XCTFail("Failed retrieving String value for fullNameItem")
             } else {
                 XCTAssertEqual(testName, value!, "Expected value to be \(testName), but instead it's \(value!)")
             }
         }
+        
         if externalIdItem != nil {
             let testId = "Test External ID"
             do {
-                try ProfileManager!.setValue(testId, forProfileKey: externalIdItem!.profileKey);
+                try profileManager!.setValue(testId, forProfileKey: externalIdItem!.profileKey);
             }
             catch {
                 XCTFail("Failed setting value for externalIdItem: unknown profile key \(externalIdItem!.profileKey)")
             }
             
-            let value = ProfileManager!.value(forProfileKey: externalIdItem!.profileKey) as? String
+            let value = profileManager!.value(forProfileKey: externalIdItem!.profileKey) as? String
             if value == nil {
                 XCTFail("Failed retrieving String value for externalIdItem")
             } else {
                 XCTAssertEqual(testId, value!, "Expected value to be \(testId), but instead it's \(value!)")
             }
         }
+        
         if genderItem != nil {
             let testGender = HKBiologicalSex.female
             do {
-                try ProfileManager!.setValue(testGender, forProfileKey: genderItem!.profileKey);
+                try profileManager!.setValue(testGender, forProfileKey: genderItem!.profileKey);
             }
             catch {
                 XCTFail("Failed setting value for genderItem: unknown profile key \(genderItem!.profileKey)")
             }
             
-            let value = ProfileManager!.value(forProfileKey: genderItem!.profileKey) as? HKBiologicalSex
+            let value = profileManager!.value(forProfileKey: genderItem!.profileKey) as? HKBiologicalSex
             if value == nil {
                 XCTFail("Failed retrieving HKBiologicalSex value for genderItem")
             } else {
                 XCTAssertEqual(testGender, value!, "Expected value to be \(testGender), but instead it's \(value!)")
             }
         }
+        
         if birthDateItem != nil {
             let testBirthDate = Date()
             do {
-                try ProfileManager!.setValue(testBirthDate, forProfileKey: birthDateItem!.profileKey);
+                try profileManager!.setValue(testBirthDate, forProfileKey: birthDateItem!.profileKey);
             }
             catch {
                 XCTFail("Failed setting value for birthDateItem: unknown profile key \(birthDateItem!.profileKey)")
             }
             
-            let value = ProfileManager!.value(forProfileKey: birthDateItem!.profileKey) as? Date
+            let value = profileManager!.value(forProfileKey: birthDateItem!.profileKey) as? Date
             if value == nil {
                 XCTFail("Failed retrieving Date value for birthDateItem")
             } else {
                 XCTAssertEqual(testBirthDate, value!, "Expected value to be \(testBirthDate), but instead it's \(value!)")
             }
         }
+        
         if favoriteColorItem != nil {
             let testColor = "Octarine"
             do {
-                try ProfileManager!.setValue(testColor, forProfileKey: favoriteColorItem!.profileKey);
+                try profileManager!.setValue(testColor, forProfileKey: favoriteColorItem!.profileKey);
             }
             catch {
                 XCTFail("Failed setting value for favoriteColorItem: unknown profile key \(favoriteColorItem!.profileKey)")
             }
             
-            let value = ProfileManager!.value(forProfileKey: favoriteColorItem!.profileKey) as? String
+            let value = profileManager!.value(forProfileKey: favoriteColorItem!.profileKey) as? String
             if value == nil {
                 XCTFail("Failed retrieving String value for favoriteColorItem")
             } else {
                 XCTAssertEqual(testColor, value!, "Expected value to be \(testColor), but instead it's \(value!)")
             }
         }
+        
         if numberOfSiblingsItem != nil {
             let testNumber = 7
             do {
-                try ProfileManager!.setValue(testNumber, forProfileKey: numberOfSiblingsItem!.profileKey);
+                try profileManager!.setValue(testNumber, forProfileKey: numberOfSiblingsItem!.profileKey);
             }
             catch {
                 XCTFail("Failed setting value for numberOfSiblingsItem: unknown profile key \(numberOfSiblingsItem!.profileKey)")
             }
             
-            let value = ProfileManager!.value(forProfileKey: numberOfSiblingsItem!.profileKey) as? Int
+            let value = profileManager!.value(forProfileKey: numberOfSiblingsItem!.profileKey) as? Int
             if value == nil {
                 XCTFail("Failed retrieving Number value for numberOfSiblingsItem")
             } else {

--- a/BridgeAppSDKTests/Test Files/ProfileDescription.json
+++ b/BridgeAppSDKTests/Test Files/ProfileDescription.json
@@ -6,6 +6,23 @@
                  "itemType": "String"
                  },
                  {
+                 "profileKey": "given",
+                 "sourceKey": "givenName",
+                 "classType": "UserProfileItem",
+                 "itemType": "String"
+                 },
+                 {
+                 "profileKey": "family",
+                 "sourceKey": "familyName",
+                 "classType": "UserProfileItem",
+                 "itemType": "String"
+                 },
+                 {
+                 "profileKey": "preferredName",
+                 "classType": "UserProfileItem",
+                 "itemType": "String"
+                 },
+                 {
                  "profileKey": "externalId",
                  "classType": "UserProfileItem",
                  "itemType": "String"


### PR DESCRIPTION
These changes allow accessing items that are stored and/or displayed by the profile manager while using the same method to access those items via the SBAUser (if defined for the profile manager).