### PR TITLE
Onboarding login

### DIFF
--- a/BridgeAppSDK.xcodeproj/project.pbxproj
+++ b/BridgeAppSDK.xcodeproj/project.pbxproj
@@ -39,6 +39,7 @@
 		FB8439201C7315030086E961 /* SBASurveyFactoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB84391F1C7315030086E961 /* SBASurveyFactoryTests.swift */; };
 		FBC45E6D1C7531E3007AA424 /* SBAConsentDocumentFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBC45E6C1C7531E3007AA424 /* SBAConsentDocumentFactory.swift */; };
 		FBE5515D1C6D267100C9E1AA /* MockORKTask.m in Sources */ = {isa = PBXBuildFile; fileRef = FBE5515C1C6D267100C9E1AA /* MockORKTask.m */; };
+		FF052EBA1ECF7567000835DB /* SBAExternalIDAssignStep.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF052EB91ECF7567000835DB /* SBAExternalIDAssignStep.swift */; };
 		FF14A0C71E984D3E007BB710 /* SBAOnboardingTableRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF14A0C61E984D3E007BB710 /* SBAOnboardingTableRow.swift */; };
 		FF14A0C91E984D72007BB710 /* SBAOnboardingTableHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF14A0C81E984D72007BB710 /* SBAOnboardingTableHeader.swift */; };
 		FF14A0F91E9C1BA2007BB710 /* SBASignUpViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF14A0F81E9C1BA2007BB710 /* SBASignUpViewController.swift */; };
@@ -55,7 +56,7 @@
 		FF24FF2B1E28C55F0016C4DF /* BridgeSDK.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FFC160921CFE672100C29AF7 /* BridgeSDK.framework */; };
 		FF24FF2C1E28C55F0016C4DF /* BridgeSDK.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = FFC160921CFE672100C29AF7 /* BridgeSDK.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		FF3075551DF6209800F2B3EA /* SBAUserProfileControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF3075541DF6209800F2B3EA /* SBAUserProfileControllerTests.swift */; };
-		FF30E5BB1CF76CBA003C0F8F /* SBAExternalIDStep.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF30E5BA1CF76CBA003C0F8F /* SBAExternalIDStep.swift */; };
+		FF30E5BB1CF76CBA003C0F8F /* SBAExternalIDLoginStep.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF30E5BA1CF76CBA003C0F8F /* SBAExternalIDLoginStep.swift */; };
 		FF35B9371D9EEC2000E0DF23 /* Tremor.json in Resources */ = {isa = PBXBuildFile; fileRef = FF35B9351D9EEC2000E0DF23 /* Tremor.json */; };
 		FF35B95A1D9F215600E0DF23 /* ActivityTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF35B9591D9F215600E0DF23 /* ActivityTableViewController.swift */; };
 		FF36DCFF1DB9726F0034C85D /* ProfileTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF36DCFE1DB9726F0034C85D /* ProfileTableViewController.swift */; };
@@ -450,6 +451,7 @@
 		FBE5515B1C6D267100C9E1AA /* MockORKTask.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MockORKTask.h; sourceTree = "<group>"; };
 		FBE5515C1C6D267100C9E1AA /* MockORKTask.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MockORKTask.m; sourceTree = "<group>"; };
 		FF0395DC1CFE283600245DE3 /* BridgeSDK.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = BridgeSDK.xcodeproj; path = BridgeSDK/BridgeSDK.xcodeproj; sourceTree = "<group>"; };
+		FF052EB91ECF7567000835DB /* SBAExternalIDAssignStep.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SBAExternalIDAssignStep.swift; sourceTree = "<group>"; };
 		FF14A0C61E984D3E007BB710 /* SBAOnboardingTableRow.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SBAOnboardingTableRow.swift; sourceTree = "<group>"; };
 		FF14A0C81E984D72007BB710 /* SBAOnboardingTableHeader.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SBAOnboardingTableHeader.swift; sourceTree = "<group>"; };
 		FF14A0F81E9C1BA2007BB710 /* SBASignUpViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SBASignUpViewController.swift; sourceTree = "<group>"; };
@@ -461,7 +463,7 @@
 		FF24FECC1E28AF4D0016C4DF /* ResearchUXFactory.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = ResearchUXFactory.xcodeproj; path = ResearchUXFactory/ResearchUXFactory.xcodeproj; sourceTree = "<group>"; };
 		FF24FEF01E28AF5A0016C4DF /* ResearchKit.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = ResearchKit.xcodeproj; path = ResearchUXFactory/ResearchKit/ResearchKit.xcodeproj; sourceTree = "<group>"; };
 		FF3075541DF6209800F2B3EA /* SBAUserProfileControllerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SBAUserProfileControllerTests.swift; sourceTree = "<group>"; };
-		FF30E5BA1CF76CBA003C0F8F /* SBAExternalIDStep.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SBAExternalIDStep.swift; sourceTree = "<group>"; };
+		FF30E5BA1CF76CBA003C0F8F /* SBAExternalIDLoginStep.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SBAExternalIDLoginStep.swift; sourceTree = "<group>"; };
 		FF35B9361D9EEC2000E0DF23 /* Base */ = {isa = PBXFileReference; lastKnownFileType = text.json; name = Base; path = Base.lproj/Tremor.json; sourceTree = "<group>"; };
 		FF35B9591D9F215600E0DF23 /* ActivityTableViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ActivityTableViewController.swift; sourceTree = "<group>"; };
 		FF36DCFE1DB9726F0034C85D /* ProfileTableViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProfileTableViewController.swift; sourceTree = "<group>"; };
@@ -935,7 +937,8 @@
 				FF9707F51DA6D5DB006E8252 /* SBAConsentSharingStep.swift */,
 				FF812A241DDCEC6700A61655 /* SBAChangeEmailStep.swift */,
 				FFDECE051D08901300434001 /* SBAEmailVerificationStep.swift */,
-				FF30E5BA1CF76CBA003C0F8F /* SBAExternalIDStep.swift */,
+				FF30E5BA1CF76CBA003C0F8F /* SBAExternalIDLoginStep.swift */,
+				FF052EB91ECF7567000835DB /* SBAExternalIDAssignStep.swift */,
 				FFDECE031D088FA600434001 /* SBALoginStep.swift */,
 				FF5242B01D81E9D0009043B3 /* SBAOnboardingStepController.swift */,
 				FF78CF9E1D0144BF002C456D /* SBARegistrationStep.swift */,
@@ -1722,6 +1725,7 @@
 				FFCF37FC1CDBB7600090452F /* SBAScheduledActivityManager.swift in Sources */,
 				FF92A6421DBFDDD900614D1F /* SBALearnItem.swift in Sources */,
 				FF3B169C1E147EF60037D1D0 /* SBAScheduledActivityDataSource.swift in Sources */,
+				FF052EBA1ECF7567000835DB /* SBAExternalIDAssignStep.swift in Sources */,
 				FFDECDF81D0758C700434001 /* SBAOnboardingSection.swift in Sources */,
 				FFDECE061D08901300434001 /* SBAEmailVerificationStep.swift in Sources */,
 				80D5F1981CE532C2002A39DF /* SBAEncryptionHelper.swift in Sources */,
@@ -1735,7 +1739,7 @@
 				FF63D0F91CD032B4007ADEE5 /* SBALog.m in Sources */,
 				FFAAF5FD1CC00D7300500929 /* SBAActivityTableViewCell.swift in Sources */,
 				80FDDC941E661B690010DFA7 /* SBAProfileSection.swift in Sources */,
-				FF30E5BB1CF76CBA003C0F8F /* SBAExternalIDStep.swift in Sources */,
+				FF30E5BB1CF76CBA003C0F8F /* SBAExternalIDLoginStep.swift in Sources */,
 				FF722C161D775BB8004B2F8B /* SBANewsFeedManager.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/BridgeAppSDK/SBABridgeManager.h
+++ b/BridgeAppSDK/SBABridgeManager.h
@@ -199,8 +199,8 @@ typedef void (^SBABridgeManagerCompletionBlock)(id _Nullable responseObject, NSE
  @param birthDate           The user's birthday in the format "YYYY-MM-DD".
  @param consentImage        Image file of the user's signature. Should be less than 10kb. Optional, can be nil.
  @param sharingScope        The scope of data sharing to which the user has consented.
- @param subpopulationGuid   The GUID of the subpopulation for which the consent is being signed.
- @param completion          A SBABridgeManagerCompletionBlock to be called upon completion. Optional.
+ @param subpopGuid          The GUID of the subpopulation for which the consent is being signed.
+ @param completionBlock     A SBABridgeManagerCompletionBlock to be called upon completion. Optional.
  */
 + (void)sendUserConsented:(NSString *)name
                 birthDate:(NSDate *)birthDate
@@ -215,7 +215,7 @@ typedef void (^SBABridgeManagerCompletionBlock)(id _Nullable responseObject, NSE
  This should only be done in response to an explicit choice on the part of the user to change the sharing scope.
  
  @param scope       The scope of data sharing to set for this user.
- @param completion  A SBABridgeManagerCompletionBlock to be called upon completion.
+ @param completionBlock  A SBABridgeManagerCompletionBlock to be called upon completion.
  */
 + (void)updateDataSharingScope:(SBBParticipantDataSharingScope)scope
                     completion:(SBABridgeManagerCompletionBlock)completionBlock;
@@ -225,7 +225,7 @@ typedef void (^SBABridgeManagerCompletionBlock)(id _Nullable responseObject, NSE
  
  @param subpopGuid The GUID of the subpopulation for which the consent signature is being withdrawn.
  @param reason     A freeform text string entered by the participant describing their reasons for withdrawing from the study. Optional, can be nil or empty.
- @param completion A SBABridgeManagerCompletionBlock to be called upon completion.
+ @param completionBlock A SBABridgeManagerCompletionBlock to be called upon completion.
 */
 + (void)withdrawConsentForSubpopulation:(NSString *)subpopGuid
                                  reason:(NSString * _Nullable)reason
@@ -239,7 +239,7 @@ typedef void (^SBABridgeManagerCompletionBlock)(id _Nullable responseObject, NSE
 
 @param daysAhead   A number of days in the future for which to retrieve available/started/scheduled activities.
 @param daysBehind  A number of days in the past for which to include previously-cached but expired and unfinished activities (ignored if the SDK was initialized with useCache=NO).
-@param completion  A SBABridgeManagerCompletionBlock to be called upon completion.
+@param completionBlock  A SBABridgeManagerCompletionBlock to be called upon completion.
 */
 + (void)fetchChangesToScheduledActivities:(NSArray <SBBScheduledActivity *> *)scheduledActivities
                                 daysAhead:(NSInteger)daysAhead
@@ -252,7 +252,7 @@ typedef void (^SBABridgeManagerCompletionBlock)(id _Nullable responseObject, NSE
  
  @param scheduledFrom   The earlier end of the desired date range for activities to be retrieved.
  @param scheduledTo     The later end of the desired date range for activities to be retrieved.
- @param completion  A SBABridgeManagerCompletionBlock to be called upon completion.
+ @param completionBlock  A SBABridgeManagerCompletionBlock to be called upon completion.
  */
 + (void)fetchScheduledActivitiesFrom:(NSDate *)scheduledFrom to:(NSDate *)scheduledTo
                           completion:(SBABridgeManagerCompletionBlock)completionBlock;
@@ -263,7 +263,7 @@ typedef void (^SBABridgeManagerCompletionBlock)(id _Nullable responseObject, NSE
  Only the startedOn and finishedOn fields of ScheduledActivity are user-writable, so only changes to those fields will have any effect on the server state.
  
  @param scheduledActivities     The list of ScheduledActivity objects whose statuses are to be updated to the API.
- @param completion              A SBABridgeManagerCompletionBlock to be called upon completion. Optional.
+ @param completionBlock              A SBABridgeManagerCompletionBlock to be called upon completion. Optional.
  */
 + (void)updateScheduledActivities:(NSArray <SBBScheduledActivity *> *)scheduledActivities
                        completion:(SBABridgeManagerCompletionBlock _Nullable)completionBlock;
@@ -272,12 +272,21 @@ typedef void (^SBABridgeManagerCompletionBlock)(id _Nullable responseObject, NSE
  Fetch a survey from the Bridge API via an activityRef (href).
  
  @param surveyReference     The href identifying the desired survey, obtained e.g. from the Schedules or Activities API.
- @param completion          A SBABridgeManagerCompletionBlock to be called upon completion.
+ @param completionBlock          A SBABridgeManagerCompletionBlock to be called upon completion.
  
  @return An NSURLSessionTask object so you can cancel or suspend/resume the request.
  */
 + (NSURLSessionTask *)loadSurvey:(SBBSurveyReference *)surveyReference completion:(SBABridgeManagerCompletionBlock)completionBlock;
 
+
+/*!
+ Add an external identifier for a participant.
+ 
+ @param externalID  An external identifier to allow this participant to be tracked outside of the Bridge-specific study.
+ @param completionBlock  A SBABridgeManagerCompletionBlock to be called upon completion.
+ 
+ */
++ (void)setExternalIdentifier:(NSString *)externalID completion:(SBABridgeManagerCompletionBlock _Nullable)completionBlock;
 
 
 #pragma mark - deprecated

--- a/BridgeAppSDK/SBABridgeManager.m
+++ b/BridgeAppSDK/SBABridgeManager.m
@@ -215,6 +215,19 @@
      }];
 }
 
++ (void)setExternalIdentifier:(NSString *)externalID completion:(SBABridgeManagerCompletionBlock _Nullable)completionBlock {
+    [SBBComponent(SBBParticipantManager) setExternalIdentifier:externalID completion:^(id  _Nullable responseObject, NSError * _Nullable error) {
+#if DEBUG
+        if (error != nil) {
+            NSLog(@"Error with setting the external identifier: %@", error);
+        }
+#endif
+        if (completionBlock) {
+            completionBlock(responseObject, error);
+        }
+    }];
+}
+
 + (void)fetchChangesToScheduledActivities:(NSArray <SBBScheduledActivity *> *)scheduledActivities
                                 daysAhead:(NSInteger)daysAhead
                                daysBehind:(NSInteger)daysBehind

--- a/BridgeAppSDK/SBAConsentDocumentFactory.swift
+++ b/BridgeAppSDK/SBAConsentDocumentFactory.swift
@@ -68,7 +68,7 @@ extension SBASurveyFactory {
     }
     
     private func isRegistrationStep(_ step: ORKStep) -> Bool {
-        return (step is SBARegistrationStep) || (step is ORKRegistrationStep) || (step is SBAExternalIDStep)
+        return (step is SBARegistrationStep) || (step is ORKRegistrationStep) || (step is SBAExternalIDLoginStep)
     }
     
     /**

--- a/BridgeAppSDK/SBAExternalIDAssignStep.swift
+++ b/BridgeAppSDK/SBAExternalIDAssignStep.swift
@@ -1,0 +1,117 @@
+//
+//  SBAExternalIDAssignStep.swift
+//  BridgeAppSDK
+//
+//  Copyright © 2017 Sage Bionetworks. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification,
+// are permitted provided that the following conditions are met:
+//
+// 1.  Redistributions of source code must retain the above copyright notice, this
+// list of conditions and the following disclaimer.
+//
+// 2.  Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation and/or
+// other materials provided with the distribution.
+//
+// 3.  Neither the name of the copyright holder(s) nor the names of any contributors
+// may be used to endorse or promote products derived from this software without
+// specific prior written permission. No license is granted to the trademarks of
+// the copyright holders even if such marks are included in this software.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+
+import ResearchKit
+
+open class SBAExternalIDAssignStep: SBAProfileFormStep {
+    
+    override open func defaultOptions(_ inputItem: SBASurveyItem?) -> [SBAProfileInfoOption] {
+        return [.externalID]
+    }
+    
+    open override func stepViewControllerClass() -> AnyClass {
+        return SBAExternalIDAssignStepViewController.classForCoder()
+    }
+
+}
+
+/**
+ Allow developers to create their own step view controllers that do not inherit from
+ `ORKFormStepViewController`.
+ */
+public protocol SBAExternalIDAssignStepController: SBAOnboardingStepController {
+    
+    /**
+     In general, this method should call through to super.goForward(). See `SBARegistrationStepViewController`
+     */
+    func goNext()
+}
+
+extension SBAExternalIDAssignStepController {
+    
+    public var failedValidationMessage: String {
+        return Localization.localizedString("SBA_REGISTRATION_INVALID_CODE")
+    }
+    
+    public var failedRegistrationTitle: String {
+        return Localization.localizedString("SBA_REGISTRATION_FAILED_TITLE")
+    }
+
+    public func updateExternalID() {
+        
+        // If the external Id is nil then do not try to set it. Just go to the next step.
+        guard let externalId = self.externalID else {
+            self.goNext()
+            return
+        }
+        
+        // If the user login is not verified, then this needs to be stored until that 
+        // step in the onboarding process is done. Store the result and continue.
+        guard sharedUser.isLoginVerified else {
+            sharedUser.externalId = externalId
+            self.goNext()
+            return
+        }
+        
+        showLoadingView()
+        sharedUser.setExternalID(externalId) { [weak self] (error) in
+            if let error = error {
+                self?.handleFailedRegistration(error)
+            }
+            else {
+                self?.goNext()
+            }
+        }
+    }
+    
+}
+
+open class SBAExternalIDAssignStepViewController: ORKFormStepViewController, SBAExternalIDAssignStepController {
+    
+    // MARK: SBASharedInfoController
+    
+    lazy public var sharedAppDelegate: SBAAppInfoDelegate = {
+        return UIApplication.shared.delegate as! SBAAppInfoDelegate
+    }()
+    
+    // Override the default method for goForward and attempt user registration. Do not allow subclasses
+    // to override this method
+    final public override func goForward() {
+        updateExternalID()
+    }
+    
+    open func goNext() {
+        // Then call super to go forward
+        super.goForward()
+    }
+}

--- a/BridgeAppSDK/SBAExternalIDLoginStep.swift
+++ b/BridgeAppSDK/SBAExternalIDLoginStep.swift
@@ -1,5 +1,5 @@
 //
-//  SBAExternalIDStep.swift
+//  SBAExternalIDLoginStep.swift
 //  BridgeAppSDK
 //
 //  Copyright © 2016 Sage Bionetworks. All rights reserved.
@@ -33,14 +33,22 @@
 
 import ResearchKit
 
+@available(*, unavailable, message: "Use `SBAExternalIDLoginStep` instead.")
+open class SBAExternalIDStep: SBAExternalIDLoginStep {
+}
+
+@available(*, unavailable, message: "Use `SBAExternalIDLoginStepViewController` instead.")
+open class SBAExternalIDStepViewController: SBAExternalIDLoginStepViewController {
+}
+
 /**
- The `SBAExternalIDStep` is used to handle registering a user where the user must be linked 
+ The `SBAExternalIDLoginStep` is used to handle registering a user where the user must be linked
  to the app via an external ID. This is used primarily by research clinics that require registering
  users anonymously without using an email account. This step requires entering the external ID twice
  to validate the ID. Then the view controller will attempt to login the user by using the external
  ID to match to a server-side list.
  */
-open class SBAExternalIDStep: ORKPageStep {
+open class SBAExternalIDLoginStep: ORKPageStep {
     
     static let initialStepIdentifier = SBAProfileInfoOption.externalID.rawValue
     static let confirmStepIdentifier = "confirm"
@@ -67,7 +75,7 @@ open class SBAExternalIDStep: ORKPageStep {
     }
     
     public init(inputItem: SBASurveyItem) {
-        let steps = SBAExternalIDStep.steps(SBAExternalIDOptions(options: inputItem.options))
+        let steps = SBAExternalIDLoginStep.steps(SBAExternalIDOptions(dictionaryRepresentation: inputItem.options ?? [:]))
         super.init(identifier: inputItem.identifier, steps: steps)
         if let title = inputItem.stepTitle {
             self.title = title
@@ -80,13 +88,13 @@ open class SBAExternalIDStep: ORKPageStep {
     }
 
     public init(identifier: String) {
-        let steps = SBAExternalIDStep.steps()
+        let steps = SBAExternalIDLoginStep.steps()
         super.init(identifier: identifier, steps: steps)
     }
     
     fileprivate class func steps(_ options: SBAExternalIDOptions = SBAExternalIDOptions()) -> [ORKStep] {
         // Create the steps that are used by this method
-        let stepIdentifiers = [SBAExternalIDStep.initialStepIdentifier, SBAExternalIDStep.confirmStepIdentifier]
+        let stepIdentifiers = [SBAExternalIDLoginStep.initialStepIdentifier, SBAExternalIDLoginStep.confirmStepIdentifier]
         let steps = stepIdentifiers.map { (stepIdentifier) -> ORKStep in
             let options = SBAProfileInfoOptions(include: .externalID, surveyItemType: .custom("externalID"), extendedOption: options)
             let step = ORKFormStep(identifier: stepIdentifier)
@@ -102,7 +110,7 @@ open class SBAExternalIDStep: ORKPageStep {
     }
     
     override open func stepViewControllerClass() -> AnyClass {
-        return SBAExternalIDStepViewController.classForCoder()
+        return SBAExternalIDLoginStepViewController.classForCoder()
     }
     
     // MARK: NSCoding
@@ -115,7 +123,7 @@ open class SBAExternalIDStep: ORKPageStep {
 /**
  Default class used to handle registration or login via External ID
  */
-open class SBAExternalIDStepViewController: ORKPageStepViewController, SBAAccountStepController {
+open class SBAExternalIDLoginStepViewController: ORKPageStepViewController, SBAAccountStepController {
     
     lazy public var sharedAppDelegate: SBAAppInfoDelegate = {
         return UIApplication.shared.delegate as! SBAAppInfoDelegate

--- a/BridgeAppSDK/SBAOnboardingManager.swift
+++ b/BridgeAppSDK/SBAOnboardingManager.swift
@@ -133,7 +133,7 @@ open class SBAOnboardingManager: NSObject, SBASharedInfoController, ORKTaskResul
         guard let sections = self.sections else { return nil }
         
         let steps: [ORKStep] = {
-            if self.tableRows != nil {
+            if self.tableRows != nil, onboardingTaskType == .signup {
                 // Get the steps as subtask steps for each section
                 return self.steps(for: onboardingTaskType, tableRow: tableRow)
             }

--- a/BridgeAppSDK/SBARegistrationStep.swift
+++ b/BridgeAppSDK/SBARegistrationStep.swift
@@ -45,7 +45,7 @@ open class SBARegistrationStep: ORKFormStep, SBAProfileInfoForm {
     }
     
     public func defaultOptions(_ inputItem: SBASurveyItem?) -> [SBAProfileInfoOption] {
-        return [.fullName, .email, .password]
+        return [.email, .password]
     }
     
     public override required init(identifier: String) {

--- a/BridgeAppSDK/SBASurveyFactory.swift
+++ b/BridgeAppSDK/SBASurveyFactory.swift
@@ -147,12 +147,25 @@ open class SBASurveyFactory : SBABaseSurveyFactory {
         switch (subtype) {
         case .registration:
             return SBARegistrationStep(inputItem: inputItem, factory: self)
+            
         case .login:
-            return SBALoginStep(inputItem: inputItem, factory: self)
+            // For the login case, return a different implementation depending upon whether or not
+            // this is login via username or externalID. For some studies, PII (email) is not collected
+            // and instead the participant is assigned an external identifier that is used to log them in.
+            let profileOptions = SBAProfileInfoOptions(inputItem: inputItem)
+            if profileOptions.includes.contains(.externalID) {
+                return SBAExternalIDLoginStep(inputItem: inputItem)
+            }
+            else {
+                return SBALoginStep(inputItem: inputItem, factory: self)
+            }
+            
         case .emailVerification:
             return SBAEmailVerificationStep(inputItem: inputItem)
+                
         case .externalID:
-            return SBAExternalIDStep(inputItem: inputItem)
+            return SBAExternalIDAssignStep(inputItem: inputItem, factory: self)
+                
         default:
             return super.createAccountStep(inputItem:inputItem, subtype: subtype)
         }

--- a/BridgeAppSDK/SBASurveyItem+Bridge.swift
+++ b/BridgeAppSDK/SBASurveyItem+Bridge.swift
@@ -391,6 +391,14 @@ extension sbb_NumberRange {
 
 extension SBBStringConstraints: SBATextFieldRange {
     
+    public var autocapitalizationType: UITextAutocapitalizationType {
+        return .none
+    }
+
+    public var keyboardType: UIKeyboardType {
+        return .default
+    }
+    
     public var validationRegex: String? {
         if self.pattern != nil {
             return self.pattern

--- a/BridgeAppSDK/SBAUserWrapper+Bridge.swift
+++ b/BridgeAppSDK/SBAUserWrapper+Bridge.swift
@@ -131,6 +131,27 @@ public extension SBAUserWrapper {
     }
     
     /**
+     Set the user's external ID.
+     
+     @note This method is only used for the participant who is already registered.
+     
+     @param externalIdentifier      The external identifier
+     @param completion              Completion handler
+    */
+    public func setExternalID(_ externalIdentifier: String, completion: ((Error?) -> Void)?) {
+        SBABridgeManager.setExternalIdentifier(externalIdentifier) { [weak self] (_, error) in
+            guard (self != nil) else { return }
+
+            // Only set the external ID if the error is nil
+            if error == nil {
+                self!.externalId = externalIdentifier
+            }
+            self!.callCompletionOnMain(error, completion: completion)
+        }
+    }
+    
+    
+    /**
      Register a user with a changed email address
      
      @param email       The email address to use for the new user

--- a/BridgeAppSDKSample/StudyOverviewViewController.swift
+++ b/BridgeAppSDKSample/StudyOverviewViewController.swift
@@ -60,7 +60,7 @@ class StudyOverviewViewController: UIViewController, ORKTaskViewControllerDelega
         appDelegate.currentUser.consentSignature = SBAConsentSignature(identifier: "signature")
         
         // Create a task with an external ID and permissions steps and display the view controller
-        let externalIDStep = SBAExternalIDStep(identifier: "externalID")
+        let externalIDStep = SBAExternalIDLoginStep(identifier: "externalID")
         let permissonsStep = SBAPermissionsStep(identifier: "permissions")
         let task = ORKOrderedTask(identifier: "registration", steps: [externalIDStep, permissonsStep])
         let vc = SBATaskViewController(task: task, taskRun: nil)

--- a/BridgeAppSDKTests/SBAAccountTests.swift
+++ b/BridgeAppSDKTests/SBAAccountTests.swift
@@ -46,10 +46,153 @@ class SBAAccountTests: XCTestCase {
         super.tearDown()
     }
     
+    // MARK: factory tests
+    
+    func testFactory_Registration() {
+        let inputItem: NSDictionary = [
+            "identifier"    : "stepA",
+            "type"          : "registration",
+            "title"         : "A title",
+            "text"          : "Some text"
+        ]
+        
+        let output = SBASurveyFactory().createSurveyStep(inputItem)
+        XCTAssertNotNil(output)
+        
+        guard let step = output as? SBARegistrationStep else {
+            XCTAssert(false, "Failed to create expected class: \(String(describing:output))")
+            return
+        }
+        
+        XCTAssertEqual(step.identifier, "stepA")
+        XCTAssertEqual(step.title, "A title")
+        XCTAssertEqual(step.text, "Some text")
+        
+        let expectedCount = 3
+        XCTAssertEqual(step.formItems?.count ?? 0, expectedCount)
+        guard let formItems = step.formItems, formItems.count == expectedCount else {
+            XCTAssert(false, "Form items are nil or do not match expected count.")
+            return
+        }
+        
+        let emailFormat = formItems.find(withIdentifier: "email")?.answerFormat
+        XCTAssertNotNil(emailFormat)
+        
+        let passwordFormat = formItems.find(withIdentifier: "password")?.answerFormat
+        XCTAssertNotNil(passwordFormat)
+    }
+    
+    func testFactory_Login() {
+        let inputItem: NSDictionary = [
+            "identifier"    : "stepA",
+            "type"          : "login",
+            "title"         : "A title",
+            "text"          : "Some text"
+        ]
+        
+        let output = SBASurveyFactory().createSurveyStep(inputItem)
+        XCTAssertNotNil(output)
+        
+        guard let step = output as? SBALoginStep else {
+            XCTAssert(false, "Failed to create expected class: \(String(describing:output))")
+            return
+        }
+        
+        XCTAssertEqual(step.identifier, "stepA")
+        XCTAssertEqual(step.title, "A title")
+        XCTAssertEqual(step.text, "Some text")
+        
+        let expectedCount = 2
+        XCTAssertEqual(step.formItems?.count ?? 0, expectedCount)
+        guard let formItems = step.formItems, formItems.count == expectedCount else {
+            XCTAssert(false, "Form items are nil or do not match expected count.")
+            return
+        }
+        
+        let emailFormat = formItems.find(withIdentifier: "email")?.answerFormat
+        XCTAssertNotNil(emailFormat)
+        
+        let passwordFormat = formItems.find(withIdentifier: "password")?.answerFormat
+        XCTAssertNotNil(passwordFormat)
+    }
+    
+    func testFactory_ExternalIDLogin() {
+        let inputItem: NSDictionary = [
+            "identifier"    : "stepA",
+            "type"          : "login",
+            "title"         : "A title",
+            "text"          : "Some text",
+            "items"         : ["externalID"]
+        ]
+        
+        let output = SBASurveyFactory().createSurveyStep(inputItem)
+        XCTAssertNotNil(output)
+        
+        guard let step = output as? SBAExternalIDLoginStep else {
+            XCTAssert(false, "Failed to create expected class: \(String(describing:output))")
+            return
+        }
+        
+        XCTAssertEqual(step.identifier, "stepA")
+        XCTAssertEqual(step.title, "A title")
+        XCTAssertEqual(step.text, "Some text")
+    }
+    
+    func testFactory_EmailVerification() {
+        let inputItem: NSDictionary = [
+            "identifier"    : "stepA",
+            "type"          : "emailVerification",
+            "title"         : "A title",
+        ]
+        
+        let output = SBASurveyFactory().createSurveyStep(inputItem)
+        XCTAssertNotNil(output)
+        
+        guard let step = output as? SBAEmailVerificationStep else {
+            XCTAssert(false, "Failed to create expected class: \(String(describing:output))")
+            return
+        }
+        
+        XCTAssertEqual(step.identifier, "stepA")
+        XCTAssertEqual(step.title, "A title")
+    }
+    
+    func testFactory_ExternalID() {
+        let inputItem: NSDictionary = [
+            "identifier"    : "stepA",
+            "type"          : "externalID",
+            "title"         : "A title",
+            "text"          : "Some text",
+            ]
+        
+        let output = SBASurveyFactory().createSurveyStep(inputItem)
+        XCTAssertNotNil(output)
+        
+        guard let step = output as? SBAExternalIDAssignStep else {
+            XCTAssert(false, "Failed to create expected class: \(String(describing:output))")
+            return
+        }
+        
+        XCTAssertEqual(step.identifier, "stepA")
+        XCTAssertEqual(step.title, "A title")
+        XCTAssertEqual(step.text, "Some text")
+        
+        let expectedCount = 1
+        XCTAssertEqual(step.formItems?.count ?? 0, expectedCount)
+        guard let formItems = step.formItems, formItems.count == expectedCount else {
+            XCTAssert(false, "Form items are nil or do not match expected count.")
+            return
+        }
+        
+        let externalIDFormat = formItems.find(withIdentifier: "externalID")?.answerFormat
+        XCTAssertNotNil(externalIDFormat)
+    }
+
+    
     // MARK: External ID
     
     func testExternalIdRegistrationStep_Navigation() {
-        let registrationStep = SBAExternalIDStep(identifier: "registration")
+        let registrationStep = SBAExternalIDLoginStep(identifier: "registration")
         
         let taskResult = ORKTaskResult(identifier: "registration")
         
@@ -73,7 +216,7 @@ class SBAAccountTests: XCTestCase {
     
     func testExternalIDRegistrationStepViewController_ExternalId_Valid() {
         
-        let registrationStep = SBAExternalIDStep(identifier: "registration")
+        let registrationStep = SBAExternalIDLoginStep(identifier: "registration")
         
         let vc = MockExternalIDRegistrationStepViewController(step: registrationStep)
         vc.firstAnswer = "ABC123"
@@ -90,7 +233,7 @@ class SBAAccountTests: XCTestCase {
     
     func testExternalIDRegistrationStepViewController_ExternalId_Invalid() {
         
-        let registrationStep = SBAExternalIDStep(identifier: "registration")
+        let registrationStep = SBAExternalIDLoginStep(identifier: "registration")
         
         let vc = MockExternalIDRegistrationStepViewController(step: registrationStep)
         vc.firstAnswer = "ABC123*"
@@ -111,7 +254,7 @@ class SBAAccountTests: XCTestCase {
     
     func testExternalIDRegistrationStepViewController_ExternalId_Empty() {
         
-        let registrationStep = SBAExternalIDStep(identifier: "registration")
+        let registrationStep = SBAExternalIDLoginStep(identifier: "registration")
         
         let vc = MockExternalIDRegistrationStepViewController(step: registrationStep)
         vc.firstAnswer = ""
@@ -132,7 +275,7 @@ class SBAAccountTests: XCTestCase {
     
     func testExternalIDRegistrationStepViewController_ExternalId_Mismatch() {
         
-        let registrationStep = SBAExternalIDStep(identifier: "registration")
+        let registrationStep = SBAExternalIDLoginStep(identifier: "registration")
         
         let vc = MockExternalIDRegistrationStepViewController(step: registrationStep)
         vc.firstAnswer = "ABC123"
@@ -363,7 +506,7 @@ class SBAAccountTests: XCTestCase {
 
 }
 
-class MockExternalIDRegistrationStepViewController : SBAExternalIDStepViewController {
+class MockExternalIDRegistrationStepViewController : SBAExternalIDLoginStepViewController {
     
     var firstAnswer: String?
     var secondAnswer: String?

--- a/BridgeAppSDKTests/SBAOnboardingManagerTests.swift
+++ b/BridgeAppSDKTests/SBAOnboardingManagerTests.swift
@@ -277,6 +277,38 @@ class SBAOnboardingManagerTests: ResourceTestCase {
         XCTAssertEqual(step.identifier, "permissions")
     }
     
+    func testCreateTask_Login() {
+        guard let manager = MockOnboardingManager(jsonNamed: "Onboarding") else { return }
+        
+        guard let task = manager.createTask(for: .login) else {
+            XCTAssert(false, "Created task is nil")
+            return
+        }
+        
+        let expectedCount = 4
+        XCTAssertEqual(task.steps.count, expectedCount)
+        guard task.steps.count == expectedCount else {
+            XCTAssert(false, "Exit early b/c step count doesn't match expected")
+            return
+        }
+        
+        var ii = 0
+        XCTAssertTrue(task.steps[ii] is SBALoginStep)
+        XCTAssertEqual(task.steps[ii].identifier, "login")
+        
+        ii = ii + 1
+        XCTAssertTrue(task.steps[ii] is SBASubtaskStep)
+        XCTAssertEqual(task.steps[ii].identifier, "consent")
+        
+        ii = ii + 1
+        XCTAssertTrue(task.steps[ii] is ORKPasscodeStep)
+        XCTAssertEqual(task.steps[ii].identifier, "passcode")
+        
+        ii = ii + 1
+        XCTAssertTrue(task.steps[ii] is SBAPermissionsStep)
+        XCTAssertEqual(task.steps[ii].identifier, "permissions")
+    }
+    
     func testCreateTask_SignUp_Row0() {
         guard let manager = MockOnboardingManager(jsonNamed: "Onboarding") else { return }
         
@@ -284,7 +316,6 @@ class SBAOnboardingManagerTests: ResourceTestCase {
             XCTAssert(false, "Created task is nil")
             return
         }
-        print(task)
         
         let expectedCount = 7
         XCTAssertEqual(task.steps.count, expectedCount)
@@ -329,7 +360,6 @@ class SBAOnboardingManagerTests: ResourceTestCase {
             XCTAssert(false, "Created task is nil")
             return
         }
-        print(task)
         
         let expectedCount = 5
         XCTAssertEqual(task.steps.count, expectedCount)


### PR DESCRIPTION
Split out external ID usage into (a) set the external ID for a registered user, (b) store the external ID for registration if not registered, OR (c) login via external ID. Also fixed onboarding manager to return appropriate steps for login verse signup.