### PR TITLE
Enable travis branch safelist

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 UserInterfaceState.xcuserstate
 BridgeAppSDK.xcodeproj/xcuserdata/*.xcuserdatad
 .DS_Store
+build/
 
 # fastlane specific
 fastlane/report.xml

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,10 @@ xcode_project: BridgeAppSDK.xcodeproj
 xcode_scheme: BridgeAppSDKSample
 cache:
 - bundler
+branches:
+  only:
+  - master
+  - /^stable-.*$/
 before_install:
 - bundle update
 - echo -e "machine github.com\n  login $CI_USER_TOKEN" >> ~/.netrc

--- a/travis/build.sh
+++ b/travis/build.sh
@@ -1,10 +1,9 @@
 #!/bin/sh
 set -ex
-# show available schemes
-# xcodebuild -list -project ./BridgeAppSDK.xcodeproj
-if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then
-    bundle exec fastlane test scheme:"BridgeAppSDK"
-elif [ "$TRAVIS_BRANCH" = "master" ]; then
+
+if [[ "$TRAVIS_PULL_REQUEST" != "false" ]]; then     # on pull requests
+    FASTLANE_EXPLICIT_OPEN_SIMULATOR=2 bundle exec fastlane scan
+elif [[ -z "$TRAVIS_TAG" && "$TRAVIS_BRANCH" == "master" ]]; then  # non-tag commits to master branch
     bundle exec fastlane ci_archive scheme:"BridgeAppSDKSample" export_method:"enterprise"
 fi
 exit $?


### PR DESCRIPTION
Setup Travis branch safelist so travis will only trigger builds on
master and release branches.