### PR TITLE
Add a navigable step as the intro step to allow for the “end early” survey

### DIFF
--- a/BridgeAppSDK.xcodeproj/project.pbxproj
+++ b/BridgeAppSDK.xcodeproj/project.pbxproj
@@ -207,6 +207,7 @@
 		FFD6AB601EDE30710075ABEF /* SBAPermissionsStep+PageSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFD6AB5F1EDE30710075ABEF /* SBAPermissionsStep+PageSource.swift */; };
 		FFD6AB931EDE844B0075ABEF /* SBAActivityInstructionStepViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFD6AB911EDE844B0075ABEF /* SBAActivityInstructionStepViewController.swift */; };
 		FFD6AB941EDE844B0075ABEF /* SBAActivityInstructionStepViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = FFD6AB921EDE844B0075ABEF /* SBAActivityInstructionStepViewController.xib */; };
+		FFDB0EA91EEB195C0074FBAC /* SBAActivityInstructionStep.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFDB0EA81EEB195C0074FBAC /* SBAActivityInstructionStep.swift */; };
 		FFDDD7F01D2DA02B00446806 /* SBAConsentReviewOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFDDD7EF1D2DA02B00446806 /* SBAConsentReviewOptions.swift */; };
 		FFDECDB71D07317B00434001 /* SBAOnboardingManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFDECDB61D07317B00434001 /* SBAOnboardingManager.swift */; };
 		FFDECDC81D07434C00434001 /* StudyOverviewViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFDECDC71D07434C00434001 /* StudyOverviewViewController.swift */; };
@@ -640,6 +641,7 @@
 		FFD6AB5F1EDE30710075ABEF /* SBAPermissionsStep+PageSource.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "SBAPermissionsStep+PageSource.swift"; sourceTree = "<group>"; };
 		FFD6AB911EDE844B0075ABEF /* SBAActivityInstructionStepViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SBAActivityInstructionStepViewController.swift; sourceTree = "<group>"; };
 		FFD6AB921EDE844B0075ABEF /* SBAActivityInstructionStepViewController.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = SBAActivityInstructionStepViewController.xib; sourceTree = "<group>"; };
+		FFDB0EA81EEB195C0074FBAC /* SBAActivityInstructionStep.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SBAActivityInstructionStep.swift; sourceTree = "<group>"; };
 		FFDDD7EF1D2DA02B00446806 /* SBAConsentReviewOptions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SBAConsentReviewOptions.swift; sourceTree = "<group>"; };
 		FFDECDB61D07317B00434001 /* SBAOnboardingManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SBAOnboardingManager.swift; sourceTree = "<group>"; };
 		FFDECDC71D07434C00434001 /* StudyOverviewViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StudyOverviewViewController.swift; sourceTree = "<group>"; };
@@ -1124,13 +1126,6 @@
 			name = "Custom Tasks";
 			sourceTree = "<group>";
 		};
-		FF7602401EE9350900438F08 /* Instruction Below Image */ = {
-			isa = PBXGroup;
-			children = (
-			);
-			name = "Instruction Below Image";
-			sourceTree = "<group>";
-		};
 		FF826EB21ED7F9C600731DD4 /* Permissions */ = {
 			isa = PBXGroup;
 			children = (
@@ -1373,7 +1368,6 @@
 				FFD6AB801EDE836F0075ABEF /* Activity Introduction Step */,
 				FF2FE7651ED4CA6C008224D0 /* BrainBaseline */,
 				FFCC3ABC1EE7277500A2A2C8 /* Completion Step */,
-				FF7602401EE9350900438F08 /* Instruction Below Image */,
 				FFADF30D1EE5DCA7005F7E1D /* Instruction Step */,
 				FF1B89791EE7682800A96DAE /* Mood Step */,
 			);
@@ -1401,6 +1395,7 @@
 		FFD6AB801EDE836F0075ABEF /* Activity Introduction Step */ = {
 			isa = PBXGroup;
 			children = (
+				FFDB0EA81EEB195C0074FBAC /* SBAActivityInstructionStep.swift */,
 				FFD6AB911EDE844B0075ABEF /* SBAActivityInstructionStepViewController.swift */,
 				FFD6AB921EDE844B0075ABEF /* SBAActivityInstructionStepViewController.xib */,
 			);
@@ -1848,6 +1843,7 @@
 				FF5CDF241DDE395900117218 /* SBADemographicDataObjectType.m in Sources */,
 				FFF0124B1EA0199700D9D9DD /* SBATaskReference.swift in Sources */,
 				FF3E30551D5A806C00347165 /* SBASurveyTask.swift in Sources */,
+				FFDB0EA91EEB195C0074FBAC /* SBAActivityInstructionStep.swift in Sources */,
 				FFA391B11D7F3DA6000957E1 /* SBACatastrophicErrorViewController.swift in Sources */,
 				808406AF1EE72B1B00C23498 /* SBAProfileSection.m in Sources */,
 				FF45F84E1CA5DBEF00EE0562 /* SBAUserWrapper+Bridge.swift in Sources */,

--- a/BridgeAppSDK/SBAActivityInstructionStep.swift
+++ b/BridgeAppSDK/SBAActivityInstructionStep.swift
@@ -1,0 +1,73 @@
+//
+//  SBAActivityInstructionStep.swift
+//  BridgeAppSDK
+//
+//  Copyright © 2017 Sage Bionetworks. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification,
+// are permitted provided that the following conditions are met:
+//
+// 1.  Redistributions of source code must retain the above copyright notice, this
+// list of conditions and the following disclaimer.
+//
+// 2.  Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation and/or
+// other materials provided with the distribution.
+//
+// 3.  Neither the name of the copyright holder(s) nor the names of any contributors
+// may be used to endorse or promote products derived from this software without
+// specific prior written permission. No license is granted to the trademarks of
+// the copyright holders even if such marks are included in this software.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+
+import UIKit
+
+open class SBAActivityInstructionStep: SBANavigationQuestionStep {
+    
+    public var schedule: SBBScheduledActivity!
+    public var taskReference: SBATaskReference!
+    
+    override open func stepViewControllerClass() -> AnyClass {
+        return SBAActivityInstructionStepViewController.self
+    }
+    
+    override open func instantiateStepViewController(with result: ORKResult) -> ORKStepViewController {
+        let vc = super.instantiateStepViewController(with: result)
+        guard let activityVC = vc as? SBAActivityInstructionStepViewController else { return vc }
+        activityVC.schedule = self.schedule
+        activityVC.taskReference = self.taskReference
+        return vc
+    }
+}
+
+extension SBAActivityInstructionStep: SBAInstructionTextProvider {
+    
+    open var instructionText: String? {
+        // `SBBSurveyQuestion` objects have `prompt` and `promptDetail` fields whereas
+        // `ORKQuestionStep` objects have `title` and `text` fields, BUT the `SBBSurveyInfoScreen`
+        // type has `title`, `prompt`, and `promptDetail`. Because of this, if an `SBBSurveyQuestion`
+        // has both a prompt and a promptDetail, then those values are mapped into title and text.
+        // Because this is an instruction step but can have navigation defined for the "I can't do this right now"
+        // button, we need to accomidate the structure of the `SBBSurveyQuestion` but map the title
+        // to the text field and the detail to be more text.
+        var text = self.title ?? ""
+        if let detail = self.text {
+            if text.characters.count > 0 {
+                text.append("\n\n")
+            }
+            text.append(detail)
+        }
+        return text
+    }
+}

--- a/BridgeAppSDK/SBAScheduledActivityManager.swift
+++ b/BridgeAppSDK/SBAScheduledActivityManager.swift
@@ -635,8 +635,10 @@ open class SBABaseScheduledActivityManager: NSObject, ORKTaskViewControllerDeleg
         let archives = results.mapAndFilter({ archive(for: $0) })
         SBBDataArchive.encryptAndUploadArchives(archives)
         
-        // Update the schedule on the server
-        update(schedule: schedule, taskViewController: taskViewController)
+        // Update the schedule on the server but only if the survey was not ended early
+        if !didEndSurveyEarly(schedule: schedule, taskViewController: taskViewController) {
+            update(schedule: schedule, taskViewController: taskViewController)
+        }
     }
     
     /**
@@ -648,9 +650,6 @@ open class SBABaseScheduledActivityManager: NSObject, ORKTaskViewControllerDeleg
      @param     taskViewController  The task view controller that was displayed.
     */
     open func update(schedule: SBBScheduledActivity, taskViewController: ORKTaskViewController) {
-        
-        // Exit early if the survey was ended without completing it (but still archive and upload result to capture reason for end survey)
-        guard !didEndSurveyEarly(schedule: schedule, taskViewController: taskViewController) else { return }
         
         // Set finish and start timestamps
         schedule.finishedOn = {

--- a/BridgeAppSDK/SBAScheduledActivityManager.swift
+++ b/BridgeAppSDK/SBAScheduledActivityManager.swift
@@ -649,6 +649,9 @@ open class SBABaseScheduledActivityManager: NSObject, ORKTaskViewControllerDeleg
     */
     open func update(schedule: SBBScheduledActivity, taskViewController: ORKTaskViewController) {
         
+        // Exit early if the survey was ended without completing it (but still archive and upload result to capture reason for end survey)
+        guard !didEndSurveyEarly(schedule: schedule, taskViewController: taskViewController) else { return }
+        
         // Set finish and start timestamps
         schedule.finishedOn = {
             if let sbaTaskViewController = taskViewController as? SBATaskViewController,
@@ -680,6 +683,15 @@ open class SBABaseScheduledActivityManager: NSObject, ORKTaskViewControllerDeleg
         
         // Send message to server
         sendUpdated(scheduledActivities: scheduledActivities)
+    }
+    
+    open func didEndSurveyEarly(schedule: SBBScheduledActivity, taskViewController: ORKTaskViewController) -> Bool {
+        if let firstStepResult = taskViewController.result.results?.first as? ORKStepResult,
+            let endResult = firstStepResult.results?.find({ $0 is SBAActivityInstructionResult }) as? SBAActivityInstructionResult,
+            endResult.didEndSurvey {
+            return true
+        }
+        return false
     }
     
     /**


### PR DESCRIPTION
The daily check-in displays a survey asking the user why they selected "I can't do this now" which is uploaded to the server.  This needs to allow the intro step to navigate *AND* needs to cancel the update to the schedule to be "finished". This allows for that navigation.