### PR TITLE
Make property public for access by Elevate

### DIFF
--- a/BridgeAppSDK/SBASignUpViewController.swift
+++ b/BridgeAppSDK/SBASignUpViewController.swift
@@ -298,7 +298,7 @@ open class SBASignUpTableCell : UITableViewCell, SBASignUpCell {
 
 open class SBASignUpTableViewController : SBASignUpViewController, UITableViewDataSource, UITableViewDelegate {
     
-    @IBOutlet weak var tableView: UITableView!
+    @IBOutlet public weak var tableView: UITableView!
     
     open override func viewDidLoad() {
         super.viewDidLoad()


### PR DESCRIPTION
Make 'tableView' on 'SBASignUpViewController' a public property so we can access it from Elevate