### PR TITLE
Update pointer and move survey creation to background thread

### DIFF
--- a/BridgeAppSDK.xcodeproj/project.pbxproj
+++ b/BridgeAppSDK.xcodeproj/project.pbxproj
@@ -176,6 +176,7 @@
 		FF92A6C71DC026AC00614D1F /* Withdraw.json in Resources */ = {isa = PBXBuildFile; fileRef = FF92A6C91DC026AC00614D1F /* Withdraw.json */; };
 		FF92A6DA1DC15FE700614D1F /* NewsfeedTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF92A6D91DC15FE700614D1F /* NewsfeedTableViewController.swift */; };
 		FF938B8D1F104FEE0041AAA5 /* SBATaskResultSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF938B8C1F104FEE0041AAA5 /* SBATaskResultSource.swift */; };
+		FF957E6C1F1E7DB20010630E /* SBADataGroupsRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF957E6B1F1E7DB20010630E /* SBADataGroupsRule.swift */; };
 		FF9634C71C9A0A6600D07595 /* SBASurveyItem+Bridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF9634C61C9A0A6600D07595 /* SBASurveyItem+Bridge.swift */; };
 		FF9707F61DA6D5DB006E8252 /* SBAConsentSharingStep.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF9707F51DA6D5DB006E8252 /* SBAConsentSharingStep.swift */; };
 		FF9708041DA7104F006E8252 /* SBAConsentSubtaskStep.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF9708031DA7104F006E8252 /* SBAConsentSubtaskStep.swift */; };
@@ -615,6 +616,7 @@
 		FF92A6C81DC026AC00614D1F /* Base */ = {isa = PBXFileReference; lastKnownFileType = text.json; name = Base; path = Base.lproj/Withdraw.json; sourceTree = "<group>"; };
 		FF92A6D91DC15FE700614D1F /* NewsfeedTableViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NewsfeedTableViewController.swift; sourceTree = "<group>"; };
 		FF938B8C1F104FEE0041AAA5 /* SBATaskResultSource.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SBATaskResultSource.swift; sourceTree = "<group>"; };
+		FF957E6B1F1E7DB20010630E /* SBADataGroupsRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SBADataGroupsRule.swift; sourceTree = "<group>"; };
 		FF9634C61C9A0A6600D07595 /* SBASurveyItem+Bridge.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "SBASurveyItem+Bridge.swift"; sourceTree = "<group>"; };
 		FF9707F51DA6D5DB006E8252 /* SBAConsentSharingStep.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SBAConsentSharingStep.swift; sourceTree = "<group>"; };
 		FF9708031DA7104F006E8252 /* SBAConsentSubtaskStep.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SBAConsentSubtaskStep.swift; sourceTree = "<group>"; };
@@ -788,6 +790,7 @@
 				FF7601B21EE7D65E00438F08 /* Custom Tasks */,
 				FFCC3ADF1EE7518B00A2A2C8 /* Custom Step UI */,
 				FF3E30371D5A7A2E00347165 /* SBABridgeTask+SBBSurveyReference.swift */,
+				FF957E6B1F1E7DB20010630E /* SBADataGroupsRule.swift */,
 				FB8439181C727BEB0086E961 /* SBASurveyFactory.swift */,
 				FF9634C61C9A0A6600D07595 /* SBASurveyItem+Bridge.swift */,
 				FF3E30541D5A806C00347165 /* SBASurveyTask.swift */,
@@ -1928,6 +1931,7 @@
 				FFCC3ADD1EE7400000A2A2C8 /* SBACompletionStepViewController.swift in Sources */,
 				FFD6AB931EDE844B0075ABEF /* SBAActivityInstructionStepViewController.swift in Sources */,
 				FF63D0F91CD032B4007ADEE5 /* SBALog.m in Sources */,
+				FF957E6C1F1E7DB20010630E /* SBADataGroupsRule.swift in Sources */,
 				FF37BE2E1ED7927100C264CB /* SBARoundedButton.swift in Sources */,
 				FFAAF5FD1CC00D7300500929 /* SBAActivityTableViewCell.swift in Sources */,
 				FFADF3101EE5DD00005F7E1D /* SBAInstructionStepViewController.swift in Sources */,

--- a/BridgeAppSDK/SBADataGroupsRule.swift
+++ b/BridgeAppSDK/SBADataGroupsRule.swift
@@ -1,0 +1,55 @@
+//
+//  SBADataGroupsRule.swift
+//  BridgeAppSDK
+//
+//  Copyright © 2017 Sage Bionetworks. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification,
+// are permitted provided that the following conditions are met:
+//
+// 1.  Redistributions of source code must retain the above copyright notice, this
+// list of conditions and the following disclaimer.
+//
+// 2.  Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation and/or
+// other materials provided with the distribution.
+//
+// 3.  Neither the name of the copyright holder(s) nor the names of any contributors
+// may be used to endorse or promote products derived from this software without
+// specific prior written permission. No license is granted to the trademarks of
+// the copyright holders even if such marks are included in this software.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+
+import ResearchKit
+import BridgeSDK
+import ResearchUXFactory
+
+public protocol SBADataGroupsRule: SBASurveyItem {
+    
+    func shouldExcludeStep(currentDataGroups: Set<String>) -> Bool
+}
+
+extension NSDictionary : SBADataGroupsRule {
+    
+    public func shouldExcludeStep(currentDataGroups: Set<String>) -> Bool {
+        guard let dataGroups = self["dataGroups"] as? [String]
+        else {
+            return false
+        }
+        return currentDataGroups.intersection(dataGroups).count == 0
+    }
+}
+
+// TODO: syoung 07/18/2017 Implement logic for the SBBSurveyElement once `beforeRules` 
+// are implemented.

--- a/BridgeAppSDK/SBALoginStep.swift
+++ b/BridgeAppSDK/SBALoginStep.swift
@@ -43,10 +43,7 @@ open class SBALoginStep: ORKFormStep, SBAProfileInfoForm, SBALearnMoreActionStep
         return false
     }
     
-    public var learnMoreAction: SBALearnMoreAction? {
-        return _learnMoreAction
-    }
-    let _learnMoreAction: SBALearnMoreAction = {
+    public var learnMoreAction: SBALearnMoreAction? = {
         let action = SBAForgotPasswordLearnMoreAction(identifier: "forgotPassword")
         action.learnMoreButtonText = Localization.localizedString("REGISTRATION_FORGOT_PASSWORD")
         return action

--- a/BridgeAppSDK/SBAProfileManager.swift
+++ b/BridgeAppSDK/SBAProfileManager.swift
@@ -90,6 +90,11 @@ public protocol SBAProfileManagerProtocol: NSObjectProtocol {
      @param key The profileKey of the item whose value is to be set.
      */
     func setValue(_ value: Any?, forProfileKey key: String) throws
+    
+    /**
+     Special-case access of the data groups via the profile manager
+     */
+    func getDataGroups() -> Set<String>
 
 }
 
@@ -211,6 +216,10 @@ open class SBAProfileManager: SBADataObject, SBAProfileManagerProtocol {
     }
     
     // MARK: SBAProfileManagerProtocol
+    
+    open func getDataGroups() -> Set<String> {
+        return self.value(forProfileKey: "participantDataGroups") as? Set<String> ?? Set<String>()
+    }
     
     /**
      @return A list of all the profile keys known to the profile manager.

--- a/BridgeAppSDK/SBASurveyFactory.swift
+++ b/BridgeAppSDK/SBASurveyFactory.swift
@@ -68,10 +68,10 @@ open class SBASurveyFactory : SBABaseSurveyFactory {
         return json["steps"] as? [NSDictionary]
     }()
     
-    // This is a time-consuming operation (b/c data groups have moved to the keychain)
-    // so use a lazy load to only load when called, but then retain the result in memory.
+    // use a lazy load to only load when called, but then retain the result in memory.
     lazy open var currentDataGroups: Set<String> = {
-        return Set((UIApplication.shared.delegate as? SBAAppDelegate)?.currentUser.dataGroups ?? [])
+        return SBAProfileManager.shared?.getDataGroups() ??
+            Set((UIApplication.shared.delegate as? SBAAppDelegate)?.currentUser.dataGroups ?? [])
     }()
     
     /**


### PR DESCRIPTION
There are a number of crashes reported in iTunes Connect when the survey factory is trying to create the survey, but the crash logs do not return an exception for *why* the app is crashing, just that it is doing so on the main thread. Since we’ve received reports that the daily check-in is crashing the app, and that survey has a lot of customization, I am suspicious that the app is crashing b/c it was blocking the main thread (taking too long - it looks at data groups which is an expensive operation) so I’ve moved building the survey to the background queue.  Additionally, as a pair of suspenders, I am explicitly retaining the references. Swift should do this automagically, but figured it wouldn’t hurt. :)