### PR TITLE
If the user signs consent but sharing is “none” then change to “study”

### DIFF
--- a/BridgeAppSDK/SBAConsentReviewStep.swift
+++ b/BridgeAppSDK/SBAConsentReviewStep.swift
@@ -203,6 +203,12 @@ extension SBAConsentReviewStepController {
         consentSignature.signatureImage = self.signatureImage
         updateUserConsentSignature(consentSignature)
         
+        // Check for sharing - if the onboarding flow does not include explicit consent then 
+        // this will not be set.
+        if sharedUser.dataSharingScope == .none {
+            sharedUser.dataSharingScope = .study
+        }
+        
         // Update the user profile info
         updateUserProfileInfo()
         


### PR DESCRIPTION
Journey PRO has the sharing scope of "none". Should be "study" once the user has signed consent.