### PR TITLE
IA 412 - animation time

### DIFF
--- a/BridgeAppSDK/SBARootViewController.swift
+++ b/BridgeAppSDK/SBARootViewController.swift
@@ -144,7 +144,7 @@ open class SBARootViewController: UIViewController {
         // Setup new view initial alpha and frame
         viewController.view.frame = self.view.bounds
         
-        let duration = animated ? 2.0 : 0.0
+        let duration = animated ? 1.0 : 0.0
         self.transition(from: self.rootViewController, to: viewController, duration: duration, options: [.transitionCrossDissolve],
                         animations: {}) { (finished) in
                             self.rootViewController.removeFromParentViewController()


### PR DESCRIPTION
change default animation time from 2 seconds to 1 second

This is the latest issue that I remember it being mentioned, but there have been random complaints about animations being slow. Moving the default time from 2 to 1 makes it feel a lot snappier and would seem to resolve the complaints.