### PR TITLE
Use next title from step if it exists

### DIFF
--- a/BridgeAppSDK/SBAGenericStepViewController.swift
+++ b/BridgeAppSDK/SBAGenericStepViewController.swift
@@ -94,7 +94,17 @@ open class SBAGenericStepViewController: ORKStepViewController, UITableViewDataS
     }
     
     open var nextTitle: String {
-        return self.continueButtonTitle ?? (self.hasNextStep() ? Localization.buttonNext() : Localization.buttonDone())
+        let stepContinueButtonTitle: String? = {
+            guard let instructionStep = self.step as? SBAInstructionStep else { return nil }
+            return instructionStep.continueButtonTitle
+        }()
+        
+        // Give priority to the title configured in the step, then the title assigned to this view controller.
+        // If still have no title, see if there are next steps and use either Localized 'next' title or 'done' title
+        
+        return stepContinueButtonTitle ??
+            (self.continueButtonTitle ??
+                (self.hasNextStep() ? Localization.buttonNext() : Localization.buttonDone()))
     }
 
     lazy var numberFormatter: NumberFormatter = {


### PR DESCRIPTION
Update the ‘generic’ view controller to get the next button title from the step, if it exists. Otherwise use the title assigned to the VC or the general localized title.