### PR TITLE
public_reloading

### DIFF
--- a/BridgeAppSDK/SBAScheduledActivityManager.swift
+++ b/BridgeAppSDK/SBAScheduledActivityManager.swift
@@ -190,7 +190,7 @@ open class SBABaseScheduledActivityManager: NSObject, ORKTaskViewControllerDeleg
             })
         }
     }
-    fileprivate var reloading: Bool = false
+    public var reloading: Bool = false
 
     
     // MARK: Data handling


### PR DESCRIPTION
This is causing a critical bug with elevateMS where loadFromServerAll is not happening.  It's not necessarily an issue with SBAScheduledActivityManager, but how I am sub-classing it

Allowing reloading variable to be set by subclasses outside the framework. 

The other option is to switch up this code...

DispatchQueue.main.async(execute: {
                self?._loadedDateRange = (start, toDate)
                self?.load(scheduledActivities: scheduledActivities)
                self?.reloading = false
            })

 and move "reloading = false" to before the call to load