### PR TITLE
IA-368

### DIFF
--- a/BridgeAppSDK/SBAGenericStepViewController.swift
+++ b/BridgeAppSDK/SBAGenericStepViewController.swift
@@ -686,9 +686,12 @@ open class SBAGenericStepViewController: ORKStepViewController, UITableViewDataS
                 
                 // set keyboard type
                 if let textAnswerFormat = answerFormat as? ORKTextAnswerFormat {
-                    // use the keyboard type defined for this step
+                    // use the keyboard properties defined for this step
                     fieldCell.textField.keyboardType = textAnswerFormat.keyboardType
                     fieldCell.textField.isSecureTextEntry = textAnswerFormat.isSecureTextEntry
+                    fieldCell.textField.autocapitalizationType = textAnswerFormat.autocapitalizationType
+                    fieldCell.textField.autocorrectionType = textAnswerFormat.autocorrectionType
+                    fieldCell.textField.spellCheckingType = textAnswerFormat.spellCheckingType
                 }
                 else {
                     // use the keyboard type appropriate for the questionType
@@ -782,11 +785,6 @@ open class SBAGenericStepViewController: ORKStepViewController, UITableViewDataS
         
         activeTextField = textField
         scroll(to: textField)
-        
-//        guard let customField = textField as? SBAStepTextField else { return }
-//        
-//        savedVerticalScrollOffet = tableView!.contentOffset.y
-//        tableView?.scrollToRow(at: customField.indexPath!, at: .middle, animated: true)
     }
     
     public func textFieldDidEndEditing(_ textField: UITextField) {


### PR DESCRIPTION
Refactor scrolling to the selected textField when it begins editing so we can scroll to the 'activeTextField' after the keyboard animation. Doing this because the tableView.scrollToRow() function need to be called after the keyboard animation completes because the tableView bounds changes during that animation.

Support Elevate PR: https://github.com/Sage-Bionetworks/elevateMS/pull/203