### PR TITLE
Fix nav view shadow

### DIFF
--- a/BridgeAppSDK/SBAGenericStepViewController.swift
+++ b/BridgeAppSDK/SBAGenericStepViewController.swift
@@ -288,7 +288,7 @@ open class SBAGenericStepViewController: ORKStepViewController, UITableViewDataS
         // need to save height of our nav view so it can be used to calculate the bottom inset (margin)
         navigationViewHeight = navigationView.systemLayoutSizeFitting(UILayoutFittingCompressedSize).height
         
-        let totalHeight = tableView.contentSize.height + navigationViewHeight
+        let totalHeight = tableView.contentSize.height + tableView.contentInset.top + navigationViewHeight
         let contentSizeExceedsTableHeight = totalHeight > tableView.frame.size.height
         
         if !useStickyNavView && contentSizeExceedsTableHeight {
@@ -846,8 +846,9 @@ open class SBAGenericStepViewController: ORKStepViewController, UITableViewDataS
     
     open func updateShadows() {
         guard let navigationView = navigationView else { return }
-        let maxY = tableView!.contentSize.height + tableView!.contentInset.top - (tableView!.bounds.size.height - navigationView.bounds.size.height)
+        let maxY = tableView!.contentSize.height - (tableView!.bounds.size.height - navigationView.bounds.size.height)
         navigationView.shouldShowShadow = tableView!.contentOffset.y < maxY
+        print("max: " + String(describing: maxY) + ", offset" + String(describing: tableView!.contentOffset.y) )
     }
 
     

--- a/BridgeAppSDK/SBAGenericStepViewController.swift
+++ b/BridgeAppSDK/SBAGenericStepViewController.swift
@@ -848,7 +848,6 @@ open class SBAGenericStepViewController: ORKStepViewController, UITableViewDataS
         guard let navigationView = navigationView else { return }
         let maxY = tableView!.contentSize.height - (tableView!.bounds.size.height - navigationView.bounds.size.height)
         navigationView.shouldShowShadow = tableView!.contentOffset.y < maxY
-        print("max: " + String(describing: maxY) + ", offset" + String(describing: tableView!.contentOffset.y) )
     }
 
     


### PR DESCRIPTION
Fix bug that prevented the navigation shadow view from showing properly when the tableView has a non-zero contentInset.top