### PR TITLE
IA-360 and IA-363

### DIFF
--- a/BridgeAppSDK/SBAGenericStepViewController.swift
+++ b/BridgeAppSDK/SBAGenericStepViewController.swift
@@ -88,7 +88,7 @@ open class SBAGenericStepViewController: ORKStepViewController, UITableViewDataS
     // We use a flag to track whether viewWillDisappear has been called because we run a check on
     // viewDidAppear to see if we have any textFields in the tableView. This check is done after a delay,
     // so we need to track if viewWillDisappear was called during the delay
-    var isViewDisappearing = false
+    var isVisible = false
     
     var tableViewInsetBottom: CGFloat {
         get {
@@ -255,7 +255,7 @@ open class SBAGenericStepViewController: ORKStepViewController, UITableViewDataS
         tableView?.endEditing(false)
         
         // track that viewWillDisappear was called
-        isViewDisappearing = true
+        isVisible = false
     }
     
     override open func viewWillAppear(_ animated: Bool) {
@@ -283,7 +283,7 @@ open class SBAGenericStepViewController: ORKStepViewController, UITableViewDataS
         }
         
         // reset our flag that tracks whether viewWillDisappear was called
-        isViewDisappearing = false
+        isVisible = true
     }
     
     override open func viewDidAppear(_ animated: Bool) {
@@ -354,7 +354,7 @@ open class SBAGenericStepViewController: ORKStepViewController, UITableViewDataS
     func checkForFirstCellTextField() {
         
         // Don't do anything if viewWillDisappear was called
-        guard isViewDisappearing == false else { return }
+        guard isVisible else { return }
         
         // If the first row in our tableView has a textField, we want it to become the first responder
         // automatically. So, first see if our first row has a textField.

--- a/BridgeAppSDK/SBAGenericStepViewController.swift
+++ b/BridgeAppSDK/SBAGenericStepViewController.swift
@@ -277,6 +277,29 @@ open class SBAGenericStepViewController: ORKStepViewController, UITableViewDataS
         }
     }
     
+    override open func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        
+        // If the first row in our tableView has a textField, we want it to become the first responder
+        // automatically. So, first see if our first row has a textField.
+        
+        guard let tableView = tableView,
+            let firstCell = tableView.visibleCells.first,
+            let textFieldCell = firstCell as? SBAStepTextFieldCell else {
+                return
+        }
+        
+        // Our first row is a textField, so tell it to become firstResponder. We must do this after a delay
+        // because of how ORKTaskViewController presents these step view controllers, which is done via a
+        // UIPageViewController. Without the delay, the textField will NOT become the firstResponder. Use a
+        // 0.3 seconds delay to give transitions and animations plenty of time to complete.
+        
+        let delay = DispatchTime.now() + .milliseconds(300)
+        DispatchQueue.main.asyncAfter(deadline: delay) {
+            textFieldCell.textField.becomeFirstResponder()
+        }
+    }
+
     override open func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
         


### PR DESCRIPTION
Override `viewDidAppear()` and add check to see if our first tableView cell is a textField cell. If it is, tell it to becomeFirstResponder. Doing this on delay because it's the only way to make it work. TextField does not respond otherwise. This is because the ORKTaskVC is presenting these step VCs via UIPageViewController's 'setViewControllers' method.

I tried another solution first: I subclassed `UIPageViewController` that's used by `ORKTaskViewController` and overrode the `setViewControllers` method then called `viewDidAppear` on the new view controller in the completion block. I thought for sure this would work, but it did not. I'm out of ideas, so implemented this solution using the delay. I understand it's a little hacky and we may not want to include it, but here it is if we want it.