### PR TITLE
update apple connect service account

### DIFF
--- a/fastlane/Appfile
+++ b/fastlane/Appfile
@@ -1,6 +1,6 @@
 # The bundle identifier of your app
 app_identifier ["org.sagebase.BridgeAppSDKSample", "org.sagebase.BridgeAppSDKSample.watchkitapp", "org.sagebase.BridgeAppSDKSample.watchkitapp.watchkitextension"]
-apple_id "apple.developer@sagebase.org" # Your Apple email address
+apple_id "appleservicer@sagebase.org" # Your Apple email address
 
 team_id "4B822CZK9N"  # Developer Portal Team ID
 

--- a/fastlane/Matchfile
+++ b/fastlane/Matchfile
@@ -5,7 +5,7 @@ type "development" # The default type, can be: appstore, adhoc, enterprise or de
 
 # The bundle identifier of your app
 app_identifier ["org.sagebase.BridgeAppSDKSample", "org.sagebase.BridgeAppSDKSample.watchkitapp", "org.sagebase.BridgeAppSDKSample.watchkitapp.watchkitextension"]
-username "apple.developer@sagebase.org" # Your Apple Developer Portal username
+username "appleservicer@sagebase.org" # Your Apple Developer Portal username
 
 readonly true
 # For all available options run `fastlane match --help`


### PR DESCRIPTION
The apple.developer@sagebase.com account is setup with MFA so it
can no longer be used as a service account. Update with new
service account for deploying to apple itunes.